### PR TITLE
Notes: Followup cleanup

### DIFF
--- a/Lib/Model/Notes.cpp
+++ b/Lib/Model/Notes.cpp
@@ -4,6 +4,15 @@
 
 #include "Notes.h"
 
+bool Notes::Event::operator==(const Notes::Event& other) const
+{
+    return this->start == other.start
+        && this->end == other.end
+        && this->pitch == other.pitch
+        && this->amplitude == other.amplitude
+        && this->bends == other.bends;
+}
+
 std::vector<Notes::Event> Notes::convert(
     const std::vector<std::vector<float>>& inNotesPG,
     const std::vector<std::vector<float>>& inOnsetsPG,
@@ -12,6 +21,7 @@ std::vector<Notes::Event> Notes::convert(
 )
 {
     std::vector<Notes::Event> events;
+    events.reserve(1000);
 
     auto n_frames = inNotesPG.size();
     if (n_frames == 0)
@@ -90,8 +100,8 @@ std::vector<Notes::Event> Notes::convert(
             amplitude /= (i - frame_idx);
 
             events.push_back(Notes::Event{
-                .start = _model_frame_to_time(frame_idx),
-                .end = _model_frame_to_time(i),
+                .start = _modelFrameToTime(frame_idx),
+                .end = _modelFrameToTime(i),
                 .pitch = freq_idx + MIDI_OFFSET,
                 .amplitude = amplitude,
             });

--- a/Lib/Model/Notes.h
+++ b/Lib/Model/Notes.h
@@ -35,7 +35,7 @@ public:
         double amplitude;
         std::vector<int> bends;
 
-        bool operator==(const struct Event&) const = default;
+        bool operator==(const struct Event&) const;
     } Event;
 
     typedef struct
@@ -58,7 +58,7 @@ public:
                                       ConvertParams inParams);
 
 private:
-    static inline double _model_frame_to_time(int frame)
+    static inline double _modelFrameToTime(int frame)
     {
         // The following are compile-time computed consts only used here.
         // If they need to be used elsewhere, please move to Constants.h

--- a/Tests/gen_note_events.py
+++ b/Tests/gen_note_events.py
@@ -57,7 +57,7 @@ n_frames = int(params["numFrames"])
 
 pitch_bend = params.get("pitchBend", None)
 
-if pitch_bend == None or pitch_bend == "none":
+if pitch_bend == None:
     include_pitch_bends = False
 elif pitch_bend == "multi":
     include_pitch_bends = True


### PR DESCRIPTION
Reserve 1000 elements for note events to avoid copying.
Rename _model_frame_to_time to _modelFrameToTime
gen_note_events.py: Remove support for the string "none" for the pitchBend key
  as there can only be one value for it and it's already the `null`/`None` value.