### PR TITLE
Attempt to get building under linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,10 @@ add_subdirectory(ThirdParty/RTNeural)
 set(BaseTargetName NeuralNote)
 
 # Set COPY_PLUGIN_AFTER_BUILD to TRUE on Mac and to FALSE on Windows due to permission issues
-if (APPLE)
-    set(COPY_PLUGIN_AFTER_BUILD TRUE)
-else ()
+if (WIN32) # which do we want for Linux?
     set(COPY_PLUGIN_AFTER_BUILD FALSE)
+else () # APPLE and LIUNX
+    set(COPY_PLUGIN_AFTER_BUILD TRUE)
 endif ()
 
 juce_add_plugin("${BaseTargetName}"
@@ -109,12 +109,24 @@ target_compile_definitions(${BaseTargetName}
         JUCE_USE_CURL=0
         JUCE_VST3_CAN_REPLACE_VST2=0)
 
-add_library(onnxruntime STATIC IMPORTED)
 
-if (APPLE)
-    set_property(TARGET onnxruntime PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/lib/libonnxruntime.a)
+
+if (LINUX)
+    # at the moment, we are getting linker errors with either the shared or static versions.
+    # add_library(onnxruntime SHARED IMPORTED)
+    add_library(onnxruntime STATIC IMPORTED)
+    set_property(TARGET onnxruntime PROPERTY IMPORTED_LOCATION
+        ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/lib/libonnxruntime.a
+        )
+
+elseif (APPLE)
+    add_library(onnxruntime STATIC IMPORTED)
+    set_property(TARGET onnxruntime PROPERTY IMPORTED_LOCATION
+        ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/lib/libonnxruntime.a
+        )
 
 elseif (WIN32)
+    add_library(onnxruntime STATIC IMPORTED)
     set_property(TARGET onnxruntime APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 
     set_target_properties(onnxruntime PROPERTIES
@@ -128,7 +140,7 @@ elseif (WIN32)
             )
 endif ()
 
-
+include_directories(${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/include)
 target_include_directories("${BaseTargetName}" PRIVATE ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/include)
 
 target_link_libraries(${BaseTargetName}

--- a/Lib/Model/Notes.cpp
+++ b/Lib/Model/Notes.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Notes.h"
+#include <cassert>
 
 bool Notes::Event::operator==(const Notes::Event& other) const
 {

--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ Now you can get back to building NeuralNote as follows:
 > .\build.bat
 ```
 
+#### Linux
+##### Dependencies
+Use you distro's package manager to install the following:
+```
+libXinerama-devel
+libXcursor-devel
+freetype2-devel
+alsa-devel
+libcurl-devel
+webkit2gtk4-devel
+```
+You need a custom build of [libonnxruntime-neuralnote](https://github.com/tiborvass/libonnxruntime-neuralnote/)
+The Build-linux script in this repo works, except it doesn't create the shared libraries in the lib directory as used by the make-archive script. Adding the following lines to the end of build-linux.sh in this repo will allow make archive to generate the appropriate archive
+```
+mkdir -p "lib"
+
+# using find to avoid cp stat errors with wildcards
+find ./onnxruntime/build/Linux_x86_64/MinSizeRel -name "libonnxruntime.so*" -exec cp {} -a lib/ \;
+```
+Then run `./make-archive.sh v1.14.1-neuralnote.0`.  When it is finished, manually copy the resultant linux archive (eg onnxruntime-v1.14.1-neuralnote.0-linux-x86_64.tar.gz) to the root of the NeuralNote repo.
+Now, running build.sh should find and extract the compiled for linux archive.
+Alternatively, manually extract the archive.  This is usedfull if you used the "dirty" build of libonnxruntime. For example
+```
+rm -rf ThirdParty/onnxruntime
+tar -C ThirdParty/ -xvf onnxruntime-neuralnote.git2067da8.dirty-linux-x86_64.tar.gz
+mv ThirdParty/onnxruntime-neuralnote.git2067da8.dirty-linux-x86_64/ ThirdParty/onnxruntime
+cp -a ThirdParty/onnxruntime/model.with_runtime_opt.ort Lib/ModelData/features_model.ort
+```
+Then run the `build-linux.sh` script.
+
+At the moment, this will fail while linking with the following error:
+```
+/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: libBasicPitchCNN.a(BasicPitchCNN.cpp.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
+/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: failed to set dynamic section sizes: bad value
+collect2: error: ld returned 1 exit status
+```
 #### IDEs
 
 Once the build script has been executed at least once, you can load this project in your favorite IDE

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ os=windows
 arch="$(uname -m)"
 file=onnxruntime.lib
 version=v1.14.1-neuralnote.1
+
 if test "$(uname -s)" = "Darwin"; then
 	os=macOS
 	arch=universal
@@ -12,6 +13,14 @@ if test "$(uname -s)" = "Darwin"; then
 	# To remove warnings about minimum macOS target versions
 	version=v1.14.1-neuralnote.2
 fi
+if test "$(uname -s)" = "Linux"; then
+	os=linux
+	arch=x86_64
+	file=libonnxruntime.so
+	# this is what gets build manually when following the libonnxruntime readme
+	version=v1.14.1-neuralnote.0
+fi
+
 dir="onnxruntime-${version}-${os}-${arch}"
 archive="$dir.tar.gz"
 


### PR DESCRIPTION
CMakeLists.txt added a linux section.  By default the libonnxruntime-neuralnote for linux builds a shared library, but the linux branch of the [gnac fork](https://github.com/gnac/libonnxruntime-neuralnote) also creates a combined static library. Both of these are, at the moment causing linker errors.     

build.sh added a linux section.  This uses the default v1.14.1-neuralnote.0 libonnxruntime archive when manually building the libonnxruntime library per its readme's make-archive script directions.    

Added #include <cassert> to Lib/Model/Notes.cpp because the Linux c++ compiler was complaining about undefined assert().    

Added Linux build instructions to Readme.md along with information about current build errors.