### PR TITLE
Linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,21 +129,37 @@ elseif (WIN32)
             MAP_IMPORTED_CONFIG_MINSIZEREL Release
             MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
     )
+elseif (UNIX)
+    set_property(TARGET onnxruntime PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/lib/libonnxruntime.a)
 endif ()
 
 
 target_include_directories("${BaseTargetName}" PRIVATE ${CMAKE_CURRENT_LIST_DIR}/ThirdParty/onnxruntime/include)
 
-target_link_libraries(${BaseTargetName}
-        PRIVATE
-        juce::juce_audio_utils
-        juce::juce_dsp
-        BasicPitchCNN
-        onnxruntime
-        bin_data
-        PUBLIC
-        juce_recommended_config_flags
-        juce_recommended_lto_flags)
+if (UNIX AND NOT APPLE)
+	target_link_libraries(${BaseTargetName}
+  	      PRIVATE
+    	    juce::juce_audio_utils
+      	  juce::juce_dsp
+	        BasicPitchCNN
+  	      onnxruntime
+    	    bin_data
+      	  PUBLIC
+        	juce_recommended_config_flags
+        	)
+else ()
+	target_link_libraries(${BaseTargetName}
+  	      PRIVATE
+    	    juce::juce_audio_utils
+      	  juce::juce_dsp
+	        BasicPitchCNN
+  	      onnxruntime
+    	    bin_data
+      	  PUBLIC
+        	juce_recommended_config_flags
+					juce_recommended_lto_flags
+        	)
+endif ()
 # juce_recommended_warning_flags)
 
 if (BUILD_UNIT_TESTS)

--- a/Lib/Components/Knob.cpp
+++ b/Lib/Components/Knob.cpp
@@ -55,7 +55,7 @@ void Knob::paint(Graphics& g)
 
     mSlider.setAlpha(alpha);
     g.setColour(juce::Colours::black.withAlpha(alpha));
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
 
     if (!mIsMouseOver || !isEnabled()) {
         g.drawMultiLineText(mLabel, 0, 73, 66, juce::Justification::centred, 0.0f);

--- a/Lib/Components/MinMaxNoteSlider.cpp
+++ b/Lib/Components/MinMaxNoteSlider.cpp
@@ -34,7 +34,7 @@ void MinMaxNoteSlider::resized()
 void MinMaxNoteSlider::paint(Graphics& g)
 {
     g.setColour(juce::Colours::black);
-    g.setFont(DROPDOWN_FONT);
+    g.setFont(UIFonts::get().DROPDOWN_FONT());
 
     g.drawText(NoteUtils::midiNoteToStr(int(mSlider.getMinValue())),
                Rectangle<int>(0, 0, 22, 12),

--- a/Lib/Components/QuantizeForceSlider.cpp
+++ b/Lib/Components/QuantizeForceSlider.cpp
@@ -31,7 +31,7 @@ void QuantizeForceSlider::resized()
 void QuantizeForceSlider::paint(Graphics& g)
 {
     g.setColour(juce::Colours::black);
-    g.setFont(DROPDOWN_FONT);
+    g.setFont(UIFonts::get().DROPDOWN_FONT());
 
     g.drawText(
         std::to_string(int(mSlider.getValue())), Rectangle<int>(133, 0, 23, 17), juce::Justification::centredRight);

--- a/Lib/Components/UIDefines.cpp
+++ b/Lib/Components/UIDefines.cpp
@@ -1,0 +1,11 @@
+#include "UIDefines.h"
+
+UIFonts* UIFonts::fts = nullptr;;
+
+UIFonts& UIFonts::get() {
+        if (nullptr == fts) {
+            fts = new UIFonts();
+        }
+
+        return *fts;
+    }

--- a/Lib/Components/UIDefines.h
+++ b/Lib/Components/UIDefines.h
@@ -9,20 +9,32 @@
 #include "BinaryData.h"
 
 // Fonts
-const juce::Typeface::Ptr MONTSERRAT_BOLD =
-    juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratBold_ttf, BinaryData::MontserratBold_ttfSize);
 
-const juce::Typeface::Ptr MONTSERRAT_SEMIBOLD =
-    juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratSemiBold_ttf, BinaryData::MontserratSemiBold_ttfSize);
+class UIFonts {
+public:
+    static UIFonts& get();
 
-const juce::Typeface::Ptr MONTSERRAT_REGULAR =
-    juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratRegular_ttf, BinaryData::MontserratRegular_ttfSize);
+    Font TITLE_FONT() { return Font(pMONTSERRAT_BOLD).withPointHeight(18.0f); }
+    Font LARGE_FONT() { return Font(pMONTSERRAT_BOLD).withPointHeight(20.0f); }
+    Font LABEL_FONT() { return Font(pMONTSERRAT_SEMIBOLD).withPointHeight(10.0f); }
+    Font DROPDOWN_FONT() { return Font(pMONTSERRAT_REGULAR).withPointHeight(10.0f); }
+    Font BUTTON_FONT() { return Font(pMONTSERRAT_BOLD).withPointHeight(12.0f); }
+    juce::Typeface::Ptr MONTSERRAT_BOLD() { return pMONTSERRAT_BOLD; }
+    juce::Typeface::Ptr MONTSERRAT_SEMIBOLD() { return pMONTSERRAT_SEMIBOLD; }
+    juce::Typeface::Ptr MONTSERRAT_REGULAR() { return pMONTSERRAT_REGULAR; }
+protected:
+    UIFonts() :
+        pMONTSERRAT_BOLD(juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratBold_ttf, BinaryData::MontserratBold_ttfSize)),
+        pMONTSERRAT_SEMIBOLD(juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratSemiBold_ttf, BinaryData::MontserratSemiBold_ttfSize)),
+        pMONTSERRAT_REGULAR(juce::Typeface::createSystemTypefaceFor(BinaryData::MontserratRegular_ttf, BinaryData::MontserratRegular_ttfSize))
+    { }
+    static UIFonts* fts;
 
-const Font TITLE_FONT = Font(MONTSERRAT_BOLD).withPointHeight(18.0f);
-const Font LARGE_FONT = Font(MONTSERRAT_BOLD).withPointHeight(20.0f);
-const Font LABEL_FONT = Font(MONTSERRAT_SEMIBOLD).withPointHeight(10.0f);
-const Font DROPDOWN_FONT = Font(MONTSERRAT_REGULAR).withPointHeight(10.0f);
-const Font BUTTON_FONT = Font(MONTSERRAT_BOLD).withPointHeight(12.0f);
+private:
+    juce::Typeface::Ptr pMONTSERRAT_BOLD;
+    juce::Typeface::Ptr pMONTSERRAT_SEMIBOLD;
+    juce::Typeface::Ptr pMONTSERRAT_REGULAR;
+};
 
 // Colors
 static const juce::Colour BLACK(juce::uint8(14), juce::uint8(14), juce::uint8(14));

--- a/NeuralNote/PluginSources/PluginEditor.cpp
+++ b/NeuralNote/PluginSources/PluginEditor.cpp
@@ -9,7 +9,7 @@ NeuralNoteEditor::NeuralNoteEditor(NeuralNoteAudioProcessor& p)
     addAndMakeVisible(*mMainView);
     setSize(1000, 640);
 
-    getLookAndFeel().setDefaultSansSerifTypeface(MONTSERRAT_REGULAR);
+    getLookAndFeel().setDefaultSansSerifTypeface(UIFonts::get().MONTSERRAT_REGULAR());
 
     mMainView->setLookAndFeel(&mNeuralNoteLnF);
 }

--- a/NeuralNote/Source/Components/AudioRegion.cpp
+++ b/NeuralNote/Source/Components/AudioRegion.cpp
@@ -51,7 +51,7 @@ void AudioRegion::paint(Graphics& g)
         g.fillRoundedRectangle(getLocalBounds().toFloat(), 4.0f);
 
         g.setColour(BLACK);
-        g.setFont(LARGE_FONT);
+        g.setFont(UIFonts::get().LARGE_FONT());
 
         if (mIsFileOver)
             g.drawText("YUMMY!", getLocalBounds(), juce::Justification::centred);

--- a/NeuralNote/Source/Components/MidiFileDrag.cpp
+++ b/NeuralNote/Source/Components/MidiFileDrag.cpp
@@ -26,7 +26,7 @@ void MidiFileDrag::paint(Graphics& g)
     g.fillRoundedRectangle(getLocalBounds().toFloat(), 4.0f);
 
     g.setColour(BLACK);
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
     g.drawText("DRAG THE MIDI FILE FROM HERE", getLocalBounds(), juce::Justification::centred);
 }
 

--- a/NeuralNote/Source/Components/MidiFileDrag.h
+++ b/NeuralNote/Source/Components/MidiFileDrag.h
@@ -31,7 +31,7 @@ public:
 private:
     NeuralNoteAudioProcessor* mProcessor;
 
-    juce::File mTempDirectory = juce::File::getSpecialLocation(juce::File::tempDirectory);
+    juce::File mTempDirectory = juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("neuralnote");
 
     MidiFileWriter mMidiFileWriter;
 };

--- a/NeuralNote/Source/Components/NeuralNoteLNF.h
+++ b/NeuralNote/Source/Components/NeuralNoteLNF.h
@@ -13,13 +13,13 @@ class NeuralNoteLNF : public juce::LookAndFeel_V4
 public:
     NeuralNoteLNF();
 
-    Font getComboBoxFont(ComboBox& /*box*/) override { return LABEL_FONT; }
+    Font getComboBoxFont(ComboBox& /*box*/) override { return UIFonts::get().LABEL_FONT(); }
 
-    Font getPopupMenuFont() override { return LABEL_FONT; }
+    Font getPopupMenuFont() override { return UIFonts::get().LABEL_FONT(); }
 
-    Font getTextButtonFont(TextButton&, int buttonHeight) override { return LARGE_FONT; };
+    Font getTextButtonFont(TextButton&, int buttonHeight) override { return UIFonts::get().LARGE_FONT(); };
 
-    Font getLabelFont(juce::Label&) override { return DROPDOWN_FONT; };
+    Font getLabelFont(juce::Label&) override { return UIFonts::get().DROPDOWN_FONT(); };
 
     void drawRotarySlider(Graphics&,
                           int x,

--- a/NeuralNote/Source/Components/NeuralNoteMainView.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.cpp
@@ -159,7 +159,7 @@ void NeuralNoteMainView::paint(Graphics& g)
     auto background_image = juce::ImageCache::getFromMemory(BinaryData::background_png, BinaryData::background_pngSize);
 
     g.drawImage(background_image, getLocalBounds().toFloat());
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
     g.drawFittedText("MUTE OUT", juce::Rectangle<int>(939, 63, 31, 23), juce::Justification::centred, 2);
 }
 

--- a/NeuralNote/Source/Components/Views/NoteOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/NoteOptionsView.cpp
@@ -74,7 +74,7 @@ void NoteOptionsView::paint(Graphics& g)
     mMinMaxNoteSlider->setAlpha(alpha);
     g.setColour(BLACK.withAlpha(alpha));
 
-    g.setFont(TITLE_FONT);
+    g.setFont(UIFonts::get().TITLE_FONT());
     g.drawText("SCALE QUANTIZE", Rectangle<int>(24, 0, 274, 17), juce::Justification::centredLeft);
 
     auto enable_rectangle = juce::Rectangle<int>(0, 0, 17, 17);
@@ -83,7 +83,7 @@ void NoteOptionsView::paint(Graphics& g)
     else
         g.drawRoundedRectangle(enable_rectangle.toFloat(), 4.0f, 1.0f);
 
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
     g.drawText("RANGE", juce::Rectangle<int>(19, mMinMaxNoteSlider->getY(), 80, 17), juce::Justification::centredLeft);
 
     g.drawText("KEY", juce::Rectangle<int>(19, mKeyDropdown->getY(), 80, 17), juce::Justification::centredLeft);

--- a/NeuralNote/Source/Components/Views/RhythmOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/RhythmOptionsView.cpp
@@ -44,7 +44,7 @@ void RhythmOptionsView::paint(Graphics& g)
 
     mQuantizationForceSlider->setAlpha(alpha);
     g.setColour(BLACK.withAlpha(alpha));
-    g.setFont(TITLE_FONT);
+    g.setFont(UIFonts::get().TITLE_FONT());
     g.drawText("TIME QUANTIZE", Rectangle<int>(24, 0, 210, 17), juce::Justification::centredLeft);
 
     auto enable_rectangle = juce::Rectangle<int>(0, 0, 17, 17);
@@ -53,7 +53,7 @@ void RhythmOptionsView::paint(Graphics& g)
     else
         g.drawRoundedRectangle(enable_rectangle.toFloat(), 4.0f, 1.0f);
 
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
 
     g.drawText("TEMPO  " + mProcessor.getTempoStr(),
                juce::Rectangle<int>(19, LEFT_SECTIONS_TOP_PAD + 47, 75, 10),

--- a/NeuralNote/Source/Components/Views/TranscriptionOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/TranscriptionOptionsView.cpp
@@ -73,7 +73,7 @@ void TranscriptionOptionsView::paint(Graphics& g)
     float alpha = isEnabled() ? 1.0f : 0.5f;
 
     g.setColour(BLACK.withAlpha(alpha));
-    g.setFont(TITLE_FONT);
+    g.setFont(UIFonts::get().TITLE_FONT());
     g.drawText("TRANSCRIPTION", Rectangle<int>(24, 0, 250, 17), juce::Justification::centredLeft);
 
     auto enable_rectangle = juce::Rectangle<int>(0, 0, 17, 17);
@@ -82,7 +82,7 @@ void TranscriptionOptionsView::paint(Graphics& g)
     else
         g.drawRoundedRectangle(enable_rectangle.toFloat(), 4.0f, 1.0f);
 
-    g.setFont(LABEL_FONT);
+    g.setFont(UIFonts::get().LABEL_FONT());
     g.drawText(
         "PITCH BEND", juce::Rectangle<int>(19, mPitchBendDropDown->getY(), 67, 17), juce::Justification::centredLeft);
 }

--- a/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
+++ b/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
@@ -23,7 +23,7 @@ VisualizationPanel::VisualizationPanel(NeuralNoteAudioProcessor* processor)
     mFileTempo->setMultiLine(false, false);
     mFileTempo->setReadOnly(false);
 
-    mFileTempo->setFont(LABEL_FONT);
+    mFileTempo->setFont(UIFonts::get().LABEL_FONT());
     mFileTempo->setJustification(juce::Justification::centred);
 
     mFileTempo->setColour(TextEditor::backgroundColourId, juce::Colours::transparentWhite);
@@ -110,7 +110,7 @@ void VisualizationPanel::paint(Graphics& g)
             Rectangle<int>(0, 0, KEYBOARD_WIDTH, mCombinedAudioMidiRegion.mAudioRegionHeight).toFloat(), 4);
 
         g.setColour(BLACK);
-        g.setFont(LABEL_FONT);
+        g.setFont(UIFonts::get().LABEL_FONT());
         g.drawFittedText(
             "MIDI\nFILE\nTEMPO", Rectangle<int>(0, 0, KEYBOARD_WIDTH, 55), juce::Justification::centred, 3);
     }


### PR DESCRIPTION
I've made NeuralNote build under Linux and was wondering if there is interest to upstream the changes. This PR would be the first step and contains the required changes to the code and the build system. The changes I was doing are:

- Remove LTO when building for Linux as it was causing undefined reference issues
- Refactor font loading into a singleton class to circumvent the "static initialization catastrophe" which seems to happen only under Linux since JUCE tries to read the `fonts.conf` XML file and the XML parser will use certain static strings that are not initialized at that time. I've written more about this here: https://github.com/DamRsn/NeuralNote/issues/33#issuecomment-1783775194
- Create folder for NeuralNote inside the received temporary directory since NeuralNote would try to erase the whole `/tmp` directory otherwise, usually taking some temp-files of other applications with it

This change also requires an accompanying change to `libonnxruntime-neuralnote` to get a Linux build there which I have also available. But first wanted to start here to gauge interest in something like this.

There is another issue with external Drag&Drop not working properly in Linux. This seems to be a JUCE issue and I have a workaround available. But since this requires patching the external JUCE dependency I think that would probably be more suitable to put into the build scripts. Also, it's not strictly required for a Linux build.

Edit: Link to patched `libonnxruntime-neuralnote`: https://github.com/polygon/libonnxruntime-neuralnote/tree/linux