### PR TITLE
Fix aif format not working. Refactor audio format management.

### DIFF
--- a/Lib/Utils/AudioUtils.cpp
+++ b/Lib/Utils/AudioUtils.cpp
@@ -53,10 +53,6 @@ StringArray getSupportedAudioFileExtensions()
         }
     }
 
-    for (auto& extension: supported_extensions) {
-        std::cout << extension << std::endl;
-    }
-    
     return supported_extensions;
 }
 

--- a/Lib/Utils/AudioUtils.cpp
+++ b/Lib/Utils/AudioUtils.cpp
@@ -17,14 +17,10 @@ bool loadAudioFile(const juce::File& inFile, AudioBuffer<float>& outBuffer, doub
     }
 
     // Register different audio formats
-    AudioFormatManager audio_format_manager;
-    audio_format_manager.registerFormat(new juce::WavAudioFormat, true);
-    audio_format_manager.registerFormat(new juce::AiffAudioFormat, false);
-    audio_format_manager.registerFormat(new juce::FlacAudioFormat, false);
-    audio_format_manager.registerFormat(new juce::OggVorbisAudioFormat, false);
+    auto audio_format_manager = createAudioFormatManager();
 
     std::unique_ptr<juce::AudioFormatReader> format_reader;
-    format_reader.reset(audio_format_manager.createReaderFor(inFile));
+    format_reader.reset(audio_format_manager->createReaderFor(inFile));
 
     // Verify format reader is not null
     if (!format_reader)
@@ -42,6 +38,37 @@ bool loadAudioFile(const juce::File& inFile, AudioBuffer<float>& outBuffer, doub
         return false;
 
     return true;
+}
+
+StringArray getSupportedAudioFileExtensions()
+{
+    StringArray supported_extensions;
+    supported_extensions.add(".mp3");
+
+    auto audio_format_manager = createAudioFormatManager();
+    for (auto format = audio_format_manager->begin(); format != audio_format_manager->end(); ++format) {
+        StringArray file_extensions = (*format)->getFileExtensions();
+        for (auto extension: file_extensions) {
+            supported_extensions.add(extension);
+        }
+    }
+
+    for (auto& extension: supported_extensions) {
+        std::cout << extension << std::endl;
+    }
+    
+    return supported_extensions;
+}
+
+std::unique_ptr<AudioFormatManager> createAudioFormatManager()
+{
+    std::unique_ptr<AudioFormatManager> audio_format_manager = std::make_unique<AudioFormatManager>();
+    audio_format_manager->registerFormat(new juce::WavAudioFormat, true);
+    audio_format_manager->registerFormat(new juce::AiffAudioFormat, false);
+    audio_format_manager->registerFormat(new juce::FlacAudioFormat, false);
+    audio_format_manager->registerFormat(new juce::OggVorbisAudioFormat, false);
+
+    return std::move(audio_format_manager);
 }
 
 void resampleBuffer(const AudioBuffer<float>& inBuffer,

--- a/Lib/Utils/AudioUtils.h
+++ b/Lib/Utils/AudioUtils.h
@@ -28,6 +28,19 @@ namespace AudioUtils
 bool loadAudioFile(const juce::File& inFile, AudioBuffer<float>& outBuffer, double& outSampleRate);
 
 /**
+ * @brief Get the Supported Audio File Extensions object (.wav, .aiff, .flac, .ogg, .mp3 ...)
+ * 
+ * @return std::vector<String> 
+ */
+StringArray getSupportedAudioFileExtensions();
+
+/**
+ * Create an AudioFormatManager with all supported audio formats registered. 
+ * @return AudioFormatManager
+ */
+std::unique_ptr<AudioFormatManager> createAudioFormatManager();
+
+/**
  * Resample an audio buffer from source sample rate to target sample rate.
  * Filters are applied if needed to prevent any aliasing.
  * @param inBuffer Audio buffer to resample

--- a/Lib/Utils/AudioUtils.h
+++ b/Lib/Utils/AudioUtils.h
@@ -30,13 +30,13 @@ bool loadAudioFile(const juce::File& inFile, AudioBuffer<float>& outBuffer, doub
 /**
  * @brief Get the Supported Audio File Extensions object (.wav, .aiff, .flac, .ogg, .mp3 ...)
  * 
- * @return std::vector<String> 
+ * @return StringArray containing all suported file extensions
  */
 StringArray getSupportedAudioFileExtensions();
 
 /**
  * Create an AudioFormatManager with all supported audio formats registered. 
- * @return AudioFormatManager
+ * @return std::unique_ptr<AudioFormatManager>
  */
 std::unique_ptr<AudioFormatManager> createAudioFormatManager();
 

--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
@@ -61,10 +61,14 @@ private:
 
     void _centerViewOnPlayhead();
 
+    bool _isFileTypeSupported(const String& filename);
+
     NeuralNoteAudioProcessor* mProcessor;
 
     juce::Viewport* mViewportPtr = nullptr;
     juce::VBlankAttachment mVBlankAttachment;
+
+    const StringArray mSupportedAudioFileExtensions;
 
     bool mShouldCenterView = false;
 


### PR DESCRIPTION
`AudioUtils`
- Added helper function to create an audio format manager
- Added helper function to get in a `StringArray` all the supported file extensions.

UI:
- Use the helper function to reject/accept a file.

- `.aif` and `.bwf` formats are now supported.

This PR addresses #96 