### PR TITLE
Fix resampling on startup

### DIFF
--- a/Lib/Utils/AudioUtils.cpp
+++ b/Lib/Utils/AudioUtils.cpp
@@ -46,9 +46,9 @@ StringArray getSupportedAudioFileExtensions()
     supported_extensions.add(".mp3");
 
     auto audio_format_manager = createAudioFormatManager();
-    for (auto format = audio_format_manager->begin(); format != audio_format_manager->end(); ++format) {
-        StringArray file_extensions = (*format)->getFileExtensions();
-        for (auto extension: file_extensions) {
+    for (auto& format: *audio_format_manager) {
+        StringArray file_extensions = format->getFileExtensions();
+        for (auto& extension: file_extensions) {
             supported_extensions.add(extension);
         }
     }
@@ -58,7 +58,7 @@ StringArray getSupportedAudioFileExtensions()
 
 std::unique_ptr<AudioFormatManager> createAudioFormatManager()
 {
-    std::unique_ptr<AudioFormatManager> audio_format_manager = std::make_unique<AudioFormatManager>();
+    auto audio_format_manager = std::make_unique<AudioFormatManager>();
     audio_format_manager->registerFormat(new juce::WavAudioFormat, true);
     audio_format_manager->registerFormat(new juce::AiffAudioFormat, false);
     audio_format_manager->registerFormat(new juce::FlacAudioFormat, false);

--- a/NeuralNote/Source/SourceAudioManager.cpp
+++ b/NeuralNote/Source/SourceAudioManager.cpp
@@ -33,7 +33,8 @@ void SourceAudioManager::prepareToPlay(double inSampleRate, int inSamplesPerBloc
     mInternalDownsampledBuffer.setSize(
         1, static_cast<int>(std::ceil(BASIC_PITCH_SAMPLE_RATE / inSampleRate * inSamplesPerBlock)) + 5);
 
-    if (mProcessor->getState() == PopulatedAudioAndMidiRegions && mSampleRate != mSourceAudioSampleRate) {
+    auto state = mProcessor->getState();
+    if ((state == PopulatedAudioAndMidiRegions || state == Processing) && mSampleRate != mSourceAudioSampleRate) {
         AudioBuffer<float> tmp_buffer;
         AudioUtils::resampleBuffer(mSourceAudio, tmp_buffer, mSourceAudioSampleRate, mSampleRate);
         mSourceAudio = std::move(tmp_buffer);


### PR DESCRIPTION
Fix issue when loading state from previous session on startup. The source audio could be at wrong sample rate leading to incorrect playback. 

It was happening because `mSampleRate` was not set and resampling on `prepareToPlay` was missed due to NeuralNote being in `Processing` state. 

Now resampling also happens in `Processing` state. No data race between `Processing` thread and main thread (`prepareToPlay`) because we're only resampling the high sample rate version of the source audio.