### PR TITLE
Update to JUCE 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@ SDKs
 
 build*
 
-cmake-build-debug
-cmake-build-release
+cmake-*
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ juce_add_plugin("${BaseTargetName}"
         # VERSION ...                               # Set this if the plugin version is different to the project version
         ICON_BIG "${CMAKE_CURRENT_LIST_DIR}/NeuralNote/Assets/logo.png"
         ICON_SMALL "${CMAKE_CURRENT_LIST_DIR}/NeuralNote/Assets/logo.png"
-        COMPANY_NAME "Dr. Audio"
+        COMPANY_NAME "Dr.Audio"
         IS_SYNTH FALSE
         NEEDS_MIDI_INPUT FALSE
         NEEDS_MIDI_OUTPUT TRUE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ juce_add_plugin("${BaseTargetName}"
         # VERSION ...                               # Set this if the plugin version is different to the project version
         ICON_BIG "${CMAKE_CURRENT_LIST_DIR}/NeuralNote/Assets/logo.png"
         ICON_SMALL "${CMAKE_CURRENT_LIST_DIR}/NeuralNote/Assets/logo.png"
-        COMPANY_NAME "Dr.Audio"
+        COMPANY_NAME "Dr. Audio"
+        BUNDLE_ID "com.draudio.neuralnote"
         IS_SYNTH FALSE
         NEEDS_MIDI_INPUT FALSE
         NEEDS_MIDI_OUTPUT TRUE

--- a/Lib/Components/UIDefines.h
+++ b/Lib/Components/UIDefines.h
@@ -18,22 +18,22 @@ const Typeface::Ptr MONTSERRAT_SEMIBOLD =
 const Typeface::Ptr MONTSERRAT_REGULAR =
     Typeface::createSystemTypefaceFor(BinaryData::MontserratRegular_ttf, BinaryData::MontserratRegular_ttfSize);
 
-const Font TITLE_FONT = Font(MONTSERRAT_BOLD).withPointHeight(18.0f);
-const Font LARGE_FONT = Font(MONTSERRAT_BOLD).withPointHeight(20.0f);
-const Font LABEL_FONT = Font(MONTSERRAT_SEMIBOLD).withPointHeight(10.0f);
-const Font DROPDOWN_FONT = Font(MONTSERRAT_REGULAR).withPointHeight(10.0f);
-const Font BUTTON_FONT = Font(MONTSERRAT_BOLD).withPointHeight(12.0f);
+const Font TITLE_FONT = Font(FontOptions(MONTSERRAT_BOLD)).withPointHeight(18.0f);
+const Font LARGE_FONT = Font(FontOptions(MONTSERRAT_BOLD)).withPointHeight(20.0f);
+const Font LABEL_FONT = Font(FontOptions(MONTSERRAT_SEMIBOLD)).withPointHeight(10.0f);
+const Font DROPDOWN_FONT = Font(FontOptions(MONTSERRAT_REGULAR)).withPointHeight(10.0f);
+const Font BUTTON_FONT = Font(FontOptions(MONTSERRAT_BOLD)).withPointHeight(12.0f);
 
 // Colors
-static const Colour BLACK(uint8(14), uint8(14), uint8(14));
-static const Colour WHITE_TRANSPARENT(uint8(255), uint8(253), uint8(246), 0.7f);
-static const Colour WHITE_SOLID(uint8(255), uint8(253), uint8(246), 1.0f);
-static const Colour WAVEFORM_COLOR(uint8(255), uint8(253), uint8(246), 0.8f);
-static const Colour WAVEFORM_BG_COLOR(uint8(0), uint8(0), uint8(0), 0.35f);
+static const Colour BLACK(static_cast<uint8>(14), static_cast<uint8>(14), static_cast<uint8>(14));
+static const Colour WHITE_TRANSPARENT(static_cast<uint8>(255), static_cast<uint8>(253), static_cast<uint8>(246), 0.7f);
+static const Colour WHITE_SOLID(static_cast<uint8>(255), static_cast<uint8>(253), static_cast<uint8>(246), 1.0f);
+static const Colour WAVEFORM_COLOR(static_cast<uint8>(255), static_cast<uint8>(253), static_cast<uint8>(246), 0.8f);
+static const Colour WAVEFORM_BG_COLOR(static_cast<uint8>(0), static_cast<uint8>(0), static_cast<uint8>(0), 0.35f);
 static const Colour RECORD_RED(246, 89, 89);
 static const Colour PINK = Colours::deeppink;
 static const Colour KNOB_GREY(218, 221, 217);
-static const Colour TRANSPARENT(uint8(0), uint8(0), uint8(0), 0.0f);
+static const Colour TRANSPARENT(static_cast<uint8>(0), static_cast<uint8>(0), static_cast<uint8>(0), 0.0f);
 
 static constexpr float DISABLED_ALPHA = 0.5f;
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ NeuralNote software and code is published under the Apache-2.0 license. See the 
 
 Here's a list of all the third party libraries used in NeuralNote and the license under which they are used.
 
-- [JUCE](https://juce.com/) (JUCE Personal)
+- [JUCE](https://juce.com/) (JUCE Starter)
 - [RTNeural](https://github.com/jatinchowdhury18/RTNeural) (BSD-3-Clause license)
 - [ONNXRuntime](https://github.com/microsoft/onnxruntime) (MIT License)
 - [ort-builder](https://github.com/olilarkin/ort-builder) (MIT License)
@@ -172,6 +172,8 @@ NeuralNote was developed by [Damien Ronssin](https://github.com/DamRsn) and [Tib
 The plugin user interface was designed by Perrine Morel.
 
 #### Contributors
+
 Many thanks to the contributors!
+
 - [jatinchowdhury18](https://github.com/jatinchowdhury18): File browser.
 - [trirpi](https://github.com/trirpi) More scale options in `SCALE QUANTIZE`.


### PR DESCRIPTION
Updated to latest version of JUCE:
- No more "Made with JUCE" splash screen.
- Benefit from all improvements

Changes in code.
- Set explicitely the bundle id for the plugin in the `CMakeLists.txt`
- Changed newly deprecated constructor of `Font`.

