### PR TITLE
Fix flickering playhead

### DIFF
--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
@@ -157,8 +157,9 @@ void CombinedAudioMidiRegion::_centerViewOnPlayhead()
         int visible_width = mViewportPtr->getWidth();
         int half_visible_width = visible_width / 2;
 
-        auto pixel_offset = (int) std::round(
-            std::max(0.0, std::min(playhead_position, (double) full_width) - (double) half_visible_width));
+        auto pixel_offset = static_cast<int>(std::round(std::max(
+            0.0,
+            std::min(playhead_position, static_cast<double>(full_width)) - static_cast<double>(half_visible_width))));
         auto prev_pixel_offset = mViewportPtr->getViewPositionX();
 
         if (pixel_offset != prev_pixel_offset)
@@ -166,7 +167,7 @@ void CombinedAudioMidiRegion::_centerViewOnPlayhead()
     }
 }
 
-bool CombinedAudioMidiRegion::_isFileTypeSupported(const String& filename)
+bool CombinedAudioMidiRegion::_isFileTypeSupported(const String& filename) const
 {
     return std::find_if(mSupportedAudioFileExtensions.begin(),
                         mSupportedAudioFileExtensions.end(),

--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
@@ -61,7 +61,7 @@ private:
 
     void _centerViewOnPlayhead();
 
-    bool _isFileTypeSupported(const String& filename);
+    bool _isFileTypeSupported(const String& filename) const;
 
     NeuralNoteAudioProcessor* mProcessor;
 

--- a/NeuralNote/Source/Components/Playhead.cpp
+++ b/NeuralNote/Source/Components/Playhead.cpp
@@ -18,18 +18,19 @@ void Playhead::resized()
 void Playhead::paint(Graphics& g)
 {
     if (mAudioSampleDuration > 0 && mProcessor->getState() == PopulatedAudioAndMidiRegions) {
-        auto playhead_x = static_cast<float>(computePlayheadPositionPixel(
-            mCurrentPlayerPlayheadTime, mAudioSampleDuration, mNumPixelsPerSecond, getWidth()));
+        auto playhead_x = static_cast<int>(std::round(computePlayheadPositionPixel(
+            mCurrentPlayerPlayheadTime, mAudioSampleDuration, mNumPixelsPerSecond, getWidth())));
 
         g.setColour(juce::Colours::white);
-        g.drawLine(playhead_x, 0, playhead_x, (float) getHeight(), 1);
+        g.drawVerticalLine(playhead_x, 0, static_cast<float>(getHeight()));
 
+        auto playhead_center_x = static_cast<float>(playhead_x) + 0.5f;
         Path triangle;
-        triangle.addTriangle(jmax(0.0f, playhead_x - mTriangleSide / 2.0f),
+        triangle.addTriangle(jmax(0.0f, playhead_center_x - mTriangleSide / 2.0f),
                              0,
-                             jmin(playhead_x + mTriangleSide / 2.0f, (float) getWidth()),
+                             jmin(playhead_center_x + mTriangleSide / 2.0f, static_cast<float>(getWidth())),
                              0,
-                             playhead_x,
+                             playhead_center_x,
                              mTriangleHeight);
         g.fillPath(triangle);
     }


### PR DESCRIPTION
Fix flickering playhead in centered mode. Simply add std::round, because of viewport rounding.