### PR TITLE
Horizontal-zoom continuation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE STRING "Minimum OS X deployment ve
 
 option(UniversalBinary "Build universal binary for mac" OFF)
 option(RTNeural_Release "When CMAKE_BUILD_TYPE=Debug, overwrite it to Release for RTNeural only" OFF)
+option(LTO "Enable Link Time Optimization" ON)
 
 if (UniversalBinary)
     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE INTERNAL "")
@@ -143,9 +144,12 @@ target_link_libraries(${BaseTargetName}
         onnxruntime
         bin_data
         PUBLIC
-        juce_recommended_config_flags
-        juce_recommended_lto_flags)
+        juce_recommended_config_flags)
 # juce_recommended_warning_flags)
+
+if (${LTO})
+    target_link_libraries(${BaseTargetName} PUBLIC juce_recommended_lto_flags)
+endif ()
 
 if (BUILD_UNIT_TESTS)
     add_subdirectory(Tests)

--- a/NeuralNote/Source/Components/AudioRegion.cpp
+++ b/NeuralNote/Source/Components/AudioRegion.cpp
@@ -5,10 +5,10 @@
 #include "AudioRegion.h"
 #include "CombinedAudioMidiRegion.h"
 
-AudioRegion::AudioRegion(NeuralNoteAudioProcessor* processor, double inNumPixelsPerSecond)
+AudioRegion::AudioRegion(NeuralNoteAudioProcessor* processor, double inBaseNumPixelsPerSecond)
     : mProcessor(processor)
-    , mPlayhead(processor, inNumPixelsPerSecond)
-    , mNumPixelsPerSecond(inNumPixelsPerSecond)
+    , mPlayhead(processor, inBaseNumPixelsPerSecond)
+    , mBaseNumPixelsPerSecond(inBaseNumPixelsPerSecond)
 {
     addAndMakeVisible(mPlayhead);
 }
@@ -86,11 +86,18 @@ void AudioRegion::mouseDown(const juce::MouseEvent& e)
                                       }
                                   });
     } else if (mProcessor->getState() == PopulatedAudioAndMidiRegions) {
-        mPlayhead.setPlayheadTime(_pixelToTime((float) e.x));
+        mPlayhead.setPlayheadTime(_pixelToTime(static_cast<float>(e.x)));
     }
+}
+
+void AudioRegion::setZoomLevel(double inZoomLevel)
+{
+    mZoomLevel = inZoomLevel;
+    mPlayhead.setZoomLevel(inZoomLevel);
+    repaint();
 }
 
 float AudioRegion::_pixelToTime(float inPixel) const
 {
-    return inPixel / static_cast<float>(mNumPixelsPerSecond);
+    return inPixel / static_cast<float>(mBaseNumPixelsPerSecond * mZoomLevel);
 }

--- a/NeuralNote/Source/Components/AudioRegion.h
+++ b/NeuralNote/Source/Components/AudioRegion.h
@@ -17,7 +17,7 @@ class CombinedAudioMidiRegion;
 class AudioRegion : public Component
 {
 public:
-    AudioRegion(NeuralNoteAudioProcessor* processor, double inNumPixelsPerSecond);
+    AudioRegion(NeuralNoteAudioProcessor* processor, double inBaseNumPixelsPerSecond);
 
     void resized() override;
 
@@ -29,6 +29,8 @@ public:
 
     void mouseDown(const juce::MouseEvent& e) override;
 
+    void setZoomLevel(double inZoomLevel);
+
 private:
     NeuralNoteAudioProcessor* mProcessor;
 
@@ -38,7 +40,8 @@ private:
 
     std::shared_ptr<juce::FileChooser> mFileChooser;
 
-    const double mNumPixelsPerSecond;
+    const double mBaseNumPixelsPerSecond;
+    double mZoomLevel = 1.0;
 
     int mThumbnailWidth = 0;
     bool mIsFileOver = false;

--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
@@ -6,18 +6,21 @@
 
 CombinedAudioMidiRegion::CombinedAudioMidiRegion(NeuralNoteAudioProcessor* processor, Keyboard& keyboard)
     : mProcessor(processor)
-    , mAudioRegion(processor, mNumPixelsPerSecond)
-    , mPianoRoll(processor, keyboard, mNumPixelsPerSecond)
     , mVBlankAttachment(this, [this]() { _onVBlankCallback(); })
     , mSupportedAudioFileExtensions(AudioUtils::getSupportedAudioFileExtensions())
+    , mAudioRegion(processor, mBaseNumPixelsPerSecond)
+    , mPianoRoll(processor, keyboard, mBaseNumPixelsPerSecond)
 {
+    mProcessor->addListenerToStateValueTree(this);
     addAndMakeVisible(mAudioRegion);
     addAndMakeVisible(mPianoRoll);
     mProcessor->getSourceAudioManager()->getAudioThumbnail()->addChangeListener(this);
+    _setZoomLevel(mProcessor->getValueTree().getProperty(NnId::ZoomLevelId, 1.0));
 }
 
 CombinedAudioMidiRegion::~CombinedAudioMidiRegion()
 {
+    mProcessor->removeListenerFromStateValueTree(this);
     mProcessor->getSourceAudioManager()->getAudioThumbnail()->removeChangeListener(this);
 }
 
@@ -36,14 +39,26 @@ bool CombinedAudioMidiRegion::isInterestedInFileDrag(const StringArray& files)
     return mProcessor->getState() == EmptyAudioAndMidiRegions || mProcessor->getState() == PopulatedAudioAndMidiRegions;
 }
 
-void CombinedAudioMidiRegion::mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel) {
+void CombinedAudioMidiRegion::mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel)
+{
     if (event.mods.isCommandDown()) {
-        mZoomLevel += wheel.deltaY;
-        mZoomLevel = std::min(mZoomLevel, mMaxZoomLevel);
-        mZoomLevel = std::max(mZoomLevel, mMinZoomLevel);
-        mPianoRoll.setZoomLevel(mZoomLevel);
-        resizeAccordingToNumSamplesAvailable();
+        auto time_start_view = mViewportPtr->getViewPositionX() / (mBaseNumPixelsPerSecond * mZoomLevel);
+        _setZoomLevel(mZoomLevel + wheel.deltaY);
+        mViewportPtr->setViewPosition(roundToInt(time_start_view * mBaseNumPixelsPerSecond * mZoomLevel), 0);
+        repaint();
+    } else {
+        if (!(mShouldCenterView && mProcessor->getState() == PopulatedAudioAndMidiRegions
+              && mProcessor->getPlayer()->isPlaying())) {
+            Component::mouseWheelMove(event, wheel);
+        }
     }
+}
+void CombinedAudioMidiRegion::mouseMagnify(const MouseEvent& event, float scaleFactor)
+{
+    auto time_start_view = mViewportPtr->getViewPositionX() / (mBaseNumPixelsPerSecond * mZoomLevel);
+    _setZoomLevel(mZoomLevel * scaleFactor);
+    mViewportPtr->setViewPosition(roundToInt(time_start_view * mBaseNumPixelsPerSecond * mZoomLevel), 0);
+    repaint();
 }
 
 void CombinedAudioMidiRegion::filesDropped(const StringArray& files, int x, int y)
@@ -97,16 +112,13 @@ void CombinedAudioMidiRegion::repaintPianoRoll()
 
 void CombinedAudioMidiRegion::resizeAccordingToNumSamplesAvailable()
 {
-    int num_samples_available = mProcessor->getSourceAudioManager()->getNumSamplesDownAcquired();
+    const double duration_available =
+        mProcessor->getSourceAudioManager()->getNumSamplesDownAcquired() / BASIC_PITCH_SAMPLE_RATE;
 
-    int thumbnail_width = static_cast<int>(std::round(
-        (mZoomLevel * num_samples_available * mNumPixelsPerSecond) / BASIC_PITCH_SAMPLE_RATE
-    ));
+    int thumbnail_width = static_cast<int>(std::round(mZoomLevel * mBaseNumPixelsPerSecond * duration_available));
     mAudioRegion.setThumbnailWidth(thumbnail_width);
 
-    int new_width = std::max(mBaseWidth, static_cast<int>(std::round(thumbnail_width * mZoomLevel)));
-    mAudioRegion.setSize(new_width, mAudioRegion.getHeight());
-    mPianoRoll.setSize(new_width, mPianoRoll.getHeight());
+    int new_width = std::max(mBaseWidth, thumbnail_width);
 
     if (new_width != getWidth()) {
         setSize(new_width, getHeight());
@@ -162,7 +174,8 @@ void CombinedAudioMidiRegion::_centerViewOnPlayhead()
         double playhead_position =
             Playhead::computePlayheadPositionPixel(mProcessor->getPlayer()->getPlayheadPositionSeconds(),
                                                    mProcessor->getSourceAudioManager()->getAudioSampleDuration(),
-                                                   mNumPixelsPerSecond,
+                                                   mBaseNumPixelsPerSecond,
+                                                   mZoomLevel,
                                                    mAudioRegion.getWidth());
 
         int full_width = mAudioRegion.getWidth();
@@ -185,4 +198,21 @@ bool CombinedAudioMidiRegion::_isFileTypeSupported(const String& filename) const
                         mSupportedAudioFileExtensions.end(),
                         [filename](const String& extension) { return filename.endsWith(extension); })
            != mSupportedAudioFileExtensions.end();
+}
+
+void CombinedAudioMidiRegion::_setZoomLevel(double inZoomLevel)
+{
+    mZoomLevel = std::clamp(inZoomLevel, mMinZoomLevel, mMaxZoomLevel);
+    mPianoRoll.setZoomLevel(mZoomLevel);
+    mAudioRegion.setZoomLevel(mZoomLevel);
+    mProcessor->getValueTree().setPropertyExcludingListener(this, NnId::ZoomLevelId, mZoomLevel, nullptr);
+    resizeAccordingToNumSamplesAvailable();
+}
+
+void CombinedAudioMidiRegion::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged,
+                                                       const Identifier& property)
+{
+    if (property == NnId::ZoomLevelId) {
+        _setZoomLevel(treeWhosePropertyHasChanged.getProperty(property));
+    }
 }

--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
@@ -46,6 +46,8 @@ public:
 
     void setCenterView(bool inShouldCenterView);
 
+    void mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel) override;
+
     AudioRegion* getAudioRegion();
 
     PianoRoll* getPianoRoll();
@@ -73,6 +75,10 @@ private:
     bool mShouldCenterView = false;
 
     int mBaseWidth = 0;
+
+    const float mMaxZoomLevel = 5.f;
+    const float mMinZoomLevel = 0.1f;
+    float mZoomLevel = 1.f;
 
     AudioRegion mAudioRegion;
     PianoRoll mPianoRoll;

--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.h
@@ -16,6 +16,7 @@ class CombinedAudioMidiRegion
     : public Component
     , public FileDragAndDropTarget
     , public ChangeListener
+    , public ValueTree::Listener
 {
 public:
     CombinedAudioMidiRegion(NeuralNoteAudioProcessor* processor, Keyboard& keyboard);
@@ -48,11 +49,13 @@ public:
 
     void mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel) override;
 
+    void mouseMagnify(const MouseEvent& event, float scaleFactor) override;
+
     AudioRegion* getAudioRegion();
 
     PianoRoll* getPianoRoll();
 
-    const double mNumPixelsPerSecond = 100.0;
+    const double mBaseNumPixelsPerSecond = 100.0;
 
     const int mAudioRegionHeight = 85;
     const int mHeightBetweenAudioMidi = 23;
@@ -65,6 +68,10 @@ private:
 
     bool _isFileTypeSupported(const String& filename) const;
 
+    void _setZoomLevel(double inZoomLevel);
+
+    void valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged, const Identifier& property) override;
+
     NeuralNoteAudioProcessor* mProcessor;
 
     juce::Viewport* mViewportPtr = nullptr;
@@ -76,9 +83,9 @@ private:
 
     int mBaseWidth = 0;
 
-    const float mMaxZoomLevel = 5.f;
-    const float mMinZoomLevel = 0.1f;
-    float mZoomLevel = 1.f;
+    const double mMaxZoomLevel = 5.0;
+    const double mMinZoomLevel = 0.1;
+    double mZoomLevel = 1.0;
 
     AudioRegion mAudioRegion;
     PianoRoll mPianoRoll;

--- a/NeuralNote/Source/Components/NeuralNoteMainView.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.cpp
@@ -124,22 +124,32 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     addAndMakeVisible(mSettingsButton.get());
 
     mSettingsMenu = std::make_unique<PopupMenu>();
+
+    // Midi out
     auto midi_out_item = PopupMenu::Item("MIDI Out");
     midi_out_item.setID(1);
     midi_out_item.setEnabled(true);
-    mSettingsMenuItemsShouldBeTicked.emplace_back(
-        1, [this] { return static_cast<bool>(mProcessor.getValueTree().getProperty(NnId::MidiOut)); });
+    mSettingsMenuItemsShouldBeTicked.emplace_back(midi_out_item.itemID, [this] {
+        return static_cast<bool>(mProcessor.getValueTree().getProperty(NnId::MidiOut));
+    });
 
     midi_out_item.setTicked(mSettingsMenuItemsShouldBeTicked.back().second());
-    auto action = [this] {
+    auto midi_out_action = [this] {
         bool midi_out_enabled = mProcessor.getValueTree().getProperty(NnId::MidiOut);
         mProcessor.getValueTree().setPropertyExcludingListener(this, NnId::MidiOut, !midi_out_enabled, nullptr);
         _updateSettingsMenuTicks();
     };
 
-    midi_out_item = midi_out_item.setAction(action);
-
+    midi_out_item = midi_out_item.setAction(midi_out_action);
     mSettingsMenu->addItem(midi_out_item);
+
+    // Reset zoom
+    auto reset_zoom_item = PopupMenu::Item("Reset Zoom");
+    reset_zoom_item.setID(2);
+    reset_zoom_item.setTicked(false);
+    auto reset_zoom_action = [this] { mProcessor.getValueTree().setProperty(NnId::ZoomLevelId, 1.0, nullptr); };
+    reset_zoom_item.setAction(reset_zoom_action);
+    mSettingsMenu->addItem(reset_zoom_item);
 
     mPopupMenuLookAndFeel = std::make_unique<PopupMenuLookAndFeel>();
     mPopupMenuLookAndFeel->setColour(PopupMenu::ColourIds::backgroundColourId, WHITE_SOLID);

--- a/NeuralNote/Source/Components/PianoRoll.cpp
+++ b/NeuralNote/Source/Components/PianoRoll.cpp
@@ -31,6 +31,10 @@ void PianoRoll::resized()
     mPlayhead.setSize(getWidth(), getHeight());
 }
 
+void PianoRoll::setZoomLevel(float zoomLevel) {
+    mZoomLevel = zoomLevel;
+}
+
 void PianoRoll::paint(Graphics& g)
 {
     Rectangle<float> local_bounds = {0, 0, static_cast<float>(getWidth()), static_cast<float>(getHeight())};
@@ -131,12 +135,12 @@ void PianoRoll::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged,
 
 float PianoRoll::_timeToPixel(float inTime) const
 {
-    return inTime * static_cast<float>(mNumPixelsPerSecond);
+    return inTime * static_cast<float>(mNumPixelsPerSecond) * mZoomLevel;
 }
 
 float PianoRoll::_pixelToTime(float inPixel) const
 {
-    return inPixel / static_cast<float>(mNumPixelsPerSecond);
+    return inPixel / static_cast<float>(mNumPixelsPerSecond) / mZoomLevel;
 }
 
 std::pair<float, float> PianoRoll::_getNoteHeightAndWidthPianoRoll(int inNote) const

--- a/NeuralNote/Source/Components/PianoRoll.h
+++ b/NeuralNote/Source/Components/PianoRoll.h
@@ -31,6 +31,8 @@ public:
 
     void mouseDown(const MouseEvent& event) override;
 
+    void setZoomLevel(float zoomLevel);
+
 private:
     void valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged, const Identifier& property) override;
 
@@ -75,6 +77,8 @@ private:
     NeuralNoteAudioProcessor* mProcessor;
 
     Playhead mPlayhead;
+
+    float mZoomLevel = 1.f;
 };
 
 #endif // PianoRoll_h

--- a/NeuralNote/Source/Components/PianoRoll.h
+++ b/NeuralNote/Source/Components/PianoRoll.h
@@ -19,7 +19,7 @@ class PianoRoll
     , ValueTree::Listener
 {
 public:
-    PianoRoll(NeuralNoteAudioProcessor* inProcessor, Keyboard& keyboard, double inNumPixelsPerSecond);
+    PianoRoll(NeuralNoteAudioProcessor* inProcessor, Keyboard& keyboard, double inBaseNumPixelsPerSecond);
 
     ~PianoRoll() override;
 
@@ -31,7 +31,7 @@ public:
 
     void mouseDown(const MouseEvent& event) override;
 
-    void setZoomLevel(float zoomLevel);
+    void setZoomLevel(double inZoomLevel);
 
 private:
     void valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged, const Identifier& property) override;
@@ -67,9 +67,10 @@ private:
 
     void _drawBeatVerticalLines(Graphics& g) const;
 
-    float _beatPosQnToPixel(double inPosQn, double inOffsetBarStart, double inSecondsPerBeat) const;
+    double _beatPosQnToPixel(double inPosQn, double inOffsetBarStart, double inSecondsPerBeat) const;
 
-    const double mNumPixelsPerSecond;
+    const double mBaseNumPixelsPerSecond;
+    double mZoomLevel = 1.0;
 
     ColourGradient mNoteGradient;
 
@@ -77,8 +78,6 @@ private:
     NeuralNoteAudioProcessor* mProcessor;
 
     Playhead mPlayhead;
-
-    float mZoomLevel = 1.f;
 };
 
 #endif // PianoRoll_h

--- a/NeuralNote/Source/Components/Playhead.h
+++ b/NeuralNote/Source/Components/Playhead.h
@@ -21,8 +21,11 @@ public:
 
     static double computePlayheadPositionPixel(double inPlayheadPositionSeconds,
                                                double inSampleDuration,
-                                               double inNumPixelPerSecond,
+                                               double inBaseNumPixelPerSecond,
+                                               double inZoomLevel,
                                                int inWidth);
+
+    void setZoomLevel(double inZoomLevel);
 
 private:
     void _onVBlankCallback();
@@ -32,7 +35,8 @@ private:
 
     double mCurrentPlayerPlayheadTime = 0;
     double mAudioSampleDuration = 0;
-    const double mNumPixelsPerSecond;
+    double mZoomLevel = 1.0;
+    const double mBaseNumPixelsPerSecond;
 
     static constexpr float mTriangleSide = 8.0f;
     static constexpr float mTriangleHeight = 0.86602540378 * mTriangleSide; // Sqrt(3) / 2

--- a/NeuralNote/Source/NnId.h
+++ b/NeuralNote/Source/NnId.h
@@ -44,6 +44,8 @@ inline static Identifier TimeQuantizeRefPosSec = "TIME_QUANTIZE_REF_POS_SECONDS"
 
 inline static Identifier ExportTempoId = "EXPORT_TEMPO";
 
+inline static Identifier ZoomLevelId = "ZOOM_LEVEL";
+
 // To be set in this specific order
 const std::vector<std::pair<Identifier, var>> OrderedStatePropertiesWithDefault = {
     {TempoId, 120.0},
@@ -56,6 +58,7 @@ const std::vector<std::pair<Identifier, var>> OrderedStatePropertiesWithDefault 
     {SourceAudioNativeSrPathId, String()},
     {PlayheadPositionSecId, 0.0},
     {PlayheadCenteredId, true},
+    {ZoomLevelId, 1.0},
     {MidiOut, false}};
 } // namespace NnId
 

--- a/README.md
+++ b/README.md
@@ -174,4 +174,6 @@ The plugin user interface was designed by Perrine Morel.
 Many thanks to the contributors!
 
 - [jatinchowdhury18](https://github.com/jatinchowdhury18): File browser.
-- [trirpi](https://github.com/trirpi) More scale options in `SCALE QUANTIZE`.
+- [trirpi](https://github.com/trirpi)
+    - More scale options in `SCALE QUANTIZE`.
+    - Horizontal zoom for the audio waveform and the piano roll.


### PR DESCRIPTION
- Added Horizontal zoom via `cmd` or `ctrl` + `scroll`, or pinch movement (`mouseMagnify`).
- Save zoom factor to app state
- Added dropdown option to reset the zoom

- Replace drawLine by fillRect calls
- Added LTO flag in CMake to control whether LTO is applied or not as it is slow.