### PR TITLE
New version available notification

### DIFF
--- a/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
+++ b/NeuralNote/Source/Components/CombinedAudioMidiRegion.cpp
@@ -213,6 +213,8 @@ void CombinedAudioMidiRegion::valueTreePropertyChanged(ValueTree& treeWhosePrope
                                                        const Identifier& property)
 {
     if (property == NnId::ZoomLevelId) {
+        auto time_start_view = mViewportPtr->getViewPositionX() / (mBaseNumPixelsPerSecond * mZoomLevel);
         _setZoomLevel(treeWhosePropertyHasChanged.getProperty(property));
+        mViewportPtr->setViewPosition(roundToInt(time_start_view * mBaseNumPixelsPerSecond * mZoomLevel), 0);
     }
 }

--- a/NeuralNote/Source/Components/NeuralNoteMainView.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.cpp
@@ -128,8 +128,9 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     mSettingsMenu = std::make_unique<PopupMenu>();
 
     // Midi out
+    int item_id = 0;
     auto midi_out_item = PopupMenu::Item("MIDI Out");
-    midi_out_item.setID(1);
+    midi_out_item.setID(++item_id);
     midi_out_item.setEnabled(true);
     mSettingsMenuItemsShouldBeTicked.emplace_back(midi_out_item.itemID, [this] {
         return static_cast<bool>(mProcessor.getValueTree().getProperty(NnId::MidiOut));
@@ -147,7 +148,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
 
     // Reset zoom
     auto reset_zoom_item = PopupMenu::Item("Reset Zoom");
-    reset_zoom_item.setID(2);
+    reset_zoom_item.setID(++item_id);
     reset_zoom_item.setTicked(false);
     auto reset_zoom_action = [this] { mProcessor.getValueTree().setProperty(NnId::ZoomLevelId, 1.0, nullptr); };
     reset_zoom_item.setAction(reset_zoom_action);
@@ -155,7 +156,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
 
     // Check for updates
     auto check_updates_item = PopupMenu::Item("Check for updates");
-    check_updates_item.setID(3);
+    check_updates_item.setID(++item_id);
     check_updates_item.setEnabled(true);
     check_updates_item.setTicked(false);
     check_updates_item.setAction([this] { mUpdateCheck->checkForUpdate(true); });
@@ -240,7 +241,7 @@ void NeuralNoteMainView::resized()
     mNoteOptions.setBounds(29, 334, 274, 133);
     mQuantizePanel.setBounds(29, 491, 274, 120);
 
-    mUpdateCheck->setBounds(685, 615, 285, 20);
+    mUpdateCheck->setBounds(680, 615, 290, 20);
 }
 
 void NeuralNoteMainView::paint(Graphics& g)

--- a/NeuralNote/Source/Components/NeuralNoteMainView.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.cpp
@@ -153,6 +153,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     reset_zoom_item.setAction(reset_zoom_action);
     mSettingsMenu->addItem(reset_zoom_item);
 
+    // Check for updates
     auto check_updates_item = PopupMenu::Item("Check for updates");
     check_updates_item.setID(3);
     check_updates_item.setEnabled(true);

--- a/NeuralNote/Source/Components/NeuralNoteMainView.h
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.h
@@ -15,6 +15,7 @@
 #include "VisualizationPanel.h"
 #include "NeuralNoteLNF.h"
 #include "NnId.h"
+#include "UpdateCheck.h"
 
 class NeuralNoteMainView
     : public Component
@@ -40,8 +41,6 @@ private:
     void valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged, const Identifier& property) override;
 
     void _updateSettingsMenuTicks();
-
-    void _checkNeuralNoteUpdateAvailable();
 
     NeuralNoteAudioProcessor& mProcessor;
     NeuralNoteLNF mLNF;
@@ -86,6 +85,8 @@ private:
     Image mBackgroundImage;
 
     int mNumCallbacksStuckInProcessingState = 0;
+
+    std::unique_ptr<UpdateCheck> mUpdateCheck;
 };
 
 #endif // PluginMainView_h

--- a/NeuralNote/Source/Components/NeuralNoteMainView.h
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.h
@@ -41,6 +41,8 @@ private:
 
     void _updateSettingsMenuTicks();
 
+    void _checkNeuralNoteUpdateAvailable();
+
     NeuralNoteAudioProcessor& mProcessor;
     NeuralNoteLNF mLNF;
 

--- a/NeuralNote/Source/Components/UpdateCheck.cpp
+++ b/NeuralNote/Source/Components/UpdateCheck.cpp
@@ -1,0 +1,114 @@
+//
+// Created by Damien Ronssin on 11/11/2024.
+//
+
+#include "UpdateCheck.h"
+
+#include "UIDefines.h"
+
+UpdateCheck::UpdateCheck()
+{
+    mUrlButton.setButtonText("See update");
+    mUrlButton.setURL(mLatestReleaseUrl);
+    mUrlButton.setFont(LABEL_FONT, false);
+    mUrlButton.setJustificationType(Justification::centred);
+    mUrlButton.setColour(HyperlinkButton::ColourIds::textColourId, Colours::blue);
+    addAndMakeVisible(mUrlButton);
+}
+
+void UpdateCheck::resized()
+{
+    mUrlButton.setBounds(215, 0, 70, getHeight());
+}
+
+void UpdateCheck::paint(Graphics& g)
+{
+    auto left_offset = mUpdateAvailable ? 0 : 48;
+    g.setColour(WHITE_SOLID);
+    g.fillRoundedRectangle(getLocalBounds().toFloat().withLeft(static_cast<float>(left_offset)), 4.0f);
+
+    g.setColour(BLACK);
+    g.setFont(LABEL_FONT);
+
+    if (mUpdateAvailable) {
+        g.drawText("A new version of NeuralNote is available:",
+                   Rectangle<int>({5 + left_offset, 0, 210, getHeight()}),
+                   Justification::centredLeft);
+    } else {
+        g.drawText("You are on the latest version of NeuralNote!",
+                   Rectangle<int>({5 + left_offset, 0, 250, getHeight()}),
+                   Justification::centredLeft);
+    }
+}
+
+void UpdateCheck::timerCallback()
+{
+    auto current_time = Time::getCurrentTime();
+    auto mouse_over = isMouseOver(true);
+
+    if (mouse_over) {
+        mHideTime = std::max(current_time + RelativeTime::seconds(mTimeIncrementOnMouseOverSeconds), mHideTime);
+    }
+
+    if (current_time >= mHideTime) {
+        _hideNotification();
+    }
+}
+
+void UpdateCheck::checkForUpdate(bool inShowNotificationOnLatestVersion)
+{
+    Thread::launch([this, inShowNotificationOnLatestVersion] {
+        URL url("https://api.github.com/repos/DamRsn/NeuralNote/releases/latest");
+
+        auto result = url.readEntireTextStream();
+
+        if (result.isEmpty()) {
+            return;
+        }
+
+        auto json = JSON::parse(result);
+
+        if (json.isObject()) {
+            const auto current_version_str = String("v") + String(JucePlugin_VersionString).trim();
+            // const auto current_version_str = String("v0.0.1");
+            auto latest_version = json.getProperty("tag_name", "unknown").toString().trim();
+
+            MessageManager::callAsync([current_version_str, latest_version, inShowNotificationOnLatestVersion, this] {
+                if (!current_version_str.equalsIgnoreCase(latest_version)) {
+                    _showNewVersionAvailableNotification();
+                } else if (inShowNotificationOnLatestVersion) {
+                    _showOnLatestVersionNotification();
+                }
+            });
+        } else {
+            jassertfalse;
+        }
+    });
+}
+
+void UpdateCheck::_showNewVersionAvailableNotification()
+{
+    mUpdateAvailable = true;
+    setVisible(true);
+    mUrlButton.setVisible(true);
+    mHideTime = Time::getCurrentTime() + RelativeTime::seconds(mNotificationDurationSeconds);
+
+    startTimerHz(5);
+}
+
+void UpdateCheck::_showOnLatestVersionNotification()
+{
+    mUpdateAvailable = false;
+    setVisible(true);
+    mUrlButton.setVisible(false);
+    mHideTime = Time::getCurrentTime() + RelativeTime::seconds(mNotificationDurationSeconds);
+
+    startTimerHz(5);
+}
+
+void UpdateCheck::_hideNotification()
+{
+    stopTimer();
+    mUrlButton.setVisible(false);
+    setVisible(false);
+}

--- a/NeuralNote/Source/Components/UpdateCheck.cpp
+++ b/NeuralNote/Source/Components/UpdateCheck.cpp
@@ -73,9 +73,9 @@ void UpdateCheck::timerCallback()
 void UpdateCheck::checkForUpdate(bool inShowNotificationOnLatestVersion)
 {
     Thread::launch([this, inShowNotificationOnLatestVersion] {
-        URL url("https://api.github.com/repos/DamRsn/NeuralNote/releases/latest");
+        const URL url("https://api.github.com/repos/DamRsn/NeuralNote/releases/latest");
 
-        auto result = url.readEntireTextStream();
+        const auto result = url.readEntireTextStream();
 
         if (result.isEmpty()) {
             return;
@@ -85,8 +85,11 @@ void UpdateCheck::checkForUpdate(bool inShowNotificationOnLatestVersion)
 
         if (json.isObject()) {
             const auto current_version_str = String("v") + String(JucePlugin_VersionString).trim();
+
+            // Uncomment this line to test the new version available notification
             // const auto current_version_str = String("v0.0.1");
-            auto latest_version = json.getProperty("tag_name", "unknown").toString().trim();
+
+            const auto latest_version = json.getProperty("tag_name", "unknown").toString().trim();
 
             MessageManager::callAsync([current_version_str, latest_version, inShowNotificationOnLatestVersion, this] {
                 if (!current_version_str.equalsIgnoreCase(latest_version)) {

--- a/NeuralNote/Source/Components/UpdateCheck.cpp
+++ b/NeuralNote/Source/Components/UpdateCheck.cpp
@@ -18,27 +18,42 @@ UpdateCheck::UpdateCheck()
 
 void UpdateCheck::resized()
 {
-    mUrlButton.setBounds(215, 0, 70, getHeight());
+    mUrlButton.setBounds(getWidth() - 65 - mPadding, 0, 65, getHeight());
 }
 
 void UpdateCheck::paint(Graphics& g)
 {
-    auto left_offset = mUpdateAvailable ? 0 : 48;
     g.setColour(WHITE_SOLID);
-    g.fillRoundedRectangle(getLocalBounds().toFloat().withLeft(static_cast<float>(left_offset)), 4.0f);
-
-    g.setColour(BLACK);
     g.setFont(LABEL_FONT);
 
+    String text;
     if (mUpdateAvailable) {
-        g.drawText("A new version of NeuralNote is available:",
-                   Rectangle<int>({5 + left_offset, 0, 210, getHeight()}),
-                   Justification::centredLeft);
+        text = "A new version of NeuralNote is available:";
     } else {
-        g.drawText("You are on the latest version of NeuralNote!",
-                   Rectangle<int>({5 + left_offset, 0, 250, getHeight()}),
-                   Justification::centredLeft);
+        text = "You are on the latest version of NeuralNote!";
     }
+
+    AttributedString attributed_string(text);
+    attributed_string.setFont(LABEL_FONT);
+    attributed_string.setJustification(Justification::centred);
+
+    TextLayout text_layout;
+    text_layout.createLayout(attributed_string, static_cast<float>(getWidth()), static_cast<float>(getHeight()));
+    float text_width = text_layout.getWidth();
+    float rectangle_width = text_width + 2 * mPadding;
+
+    if (mUpdateAvailable) {
+        rectangle_width += static_cast<float>(mUrlButton.getWidth());
+    }
+
+    int rect_x_start = getWidth() - static_cast<int>(rectangle_width);
+
+    g.fillRoundedRectangle(getLocalBounds().toFloat().withLeft(static_cast<float>(rect_x_start)), 4.0f);
+
+    g.setColour(BLACK);
+    text_layout.draw(
+        g,
+        Rectangle<float>(static_cast<float>(rect_x_start + mPadding), 0, text_width, static_cast<float>(getHeight())));
 }
 
 void UpdateCheck::timerCallback()

--- a/NeuralNote/Source/Components/UpdateCheck.h
+++ b/NeuralNote/Source/Components/UpdateCheck.h
@@ -35,6 +35,8 @@ private:
 
     Time mHideTime;
 
+    static constexpr int mPadding = 5;
+
     static constexpr double mNotificationDurationSeconds = 10.0f;
     static constexpr double mTimeIncrementOnMouseOverSeconds = 3.0f;
 

--- a/NeuralNote/Source/Components/UpdateCheck.h
+++ b/NeuralNote/Source/Components/UpdateCheck.h
@@ -1,0 +1,44 @@
+//
+// Created by Damien Ronssin on 11/11/2024.
+//
+
+#ifndef UPDATECHECK_H
+#define UPDATECHECK_H
+
+#include <JuceHeader.h>
+
+class UpdateCheck
+    : public Component
+    , public Timer
+{
+public:
+    UpdateCheck();
+
+    void resized() override;
+
+    void paint(Graphics& g) override;
+
+    void timerCallback() override;
+
+    void checkForUpdate(bool inShowNotificationOnLatestVersion);
+
+private:
+    void _showNewVersionAvailableNotification();
+
+    void _showOnLatestVersionNotification();
+
+    void _hideNotification();
+
+    bool mUpdateAvailable {false};
+
+    HyperlinkButton mUrlButton;
+
+    Time mHideTime;
+
+    static constexpr double mNotificationDurationSeconds = 10.0f;
+    static constexpr double mTimeIncrementOnMouseOverSeconds = 3.0f;
+
+    const URL mLatestReleaseUrl {"https://github.com/DamRsn/NeuralNote/releases/latest"};
+};
+
+#endif //UPDATECHECK_H


### PR DESCRIPTION
Check if an update is available.
- On construction of `NeuralNoteMainView`
- When `Check for updates` is clicked from settings popup menu.
- Checks the github api url to get the latest version of NeuralNote and compare with local version.

Small notification on the bottom left corner, with link to the latest release on github. 
Shows for 10 seconds.

Fix Reset Zoom Level from settings popup. Keep the current position in the view.