### PR TITLE
Keyboard shortcut and tooltips

### DIFF
--- a/Lib/Components/Knob.cpp
+++ b/Lib/Components/Knob.cpp
@@ -65,3 +65,8 @@ void Knob::mouseExit(const MouseEvent& event)
         repaint();
     }
 }
+
+void Knob::setTooltip(const String& inTooltip)
+{
+    mSlider.setTooltip(inTooltip);
+}

--- a/Lib/Components/Knob.h
+++ b/Lib/Components/Knob.h
@@ -27,6 +27,8 @@ public:
 
     Slider& getSlider() { return mSlider; }
 
+    void setTooltip(const String& inTooltip);
+
 private:
     juce::Slider mSlider;
     std::unique_ptr<juce::SliderParameterAttachment> mSliderParameterAttachment;

--- a/Lib/Components/MinMaxNoteSlider.cpp
+++ b/Lib/Components/MinMaxNoteSlider.cpp
@@ -35,3 +35,8 @@ void MinMaxNoteSlider::paint(Graphics& g)
                Rectangle<int>(168, 0, 22, 12),
                juce::Justification::centredRight);
 }
+
+void MinMaxNoteSlider::setTooltip(const String& inTooltip)
+{
+    mSlider.setTooltip(inTooltip);
+}

--- a/Lib/Components/MinMaxNoteSlider.h
+++ b/Lib/Components/MinMaxNoteSlider.h
@@ -90,6 +90,8 @@ public:
 
     void paint(Graphics& g) override;
 
+    void setTooltip(const String& inTooltip);
+
 private:
     juce::Slider mSlider;
     std::unique_ptr<TwoValueAttachment> mAttachment;

--- a/Lib/Components/QuantizeForceSlider.cpp
+++ b/Lib/Components/QuantizeForceSlider.cpp
@@ -28,7 +28,12 @@ void QuantizeForceSlider::paint(Graphics& g)
     g.setColour(juce::Colours::black);
     g.setFont(DROPDOWN_FONT);
 
-    g.drawText(std::to_string((int) std::round(mSlider.getValue() * 100.0f)),
+    g.drawText(std::to_string(static_cast<int>(std::round(mSlider.getValue() * 100.0f))),
                Rectangle<int>(133, 0, 23, 17),
                juce::Justification::centredRight);
+}
+
+void QuantizeForceSlider::setTooltip(const String& inTooltip)
+{
+    mSlider.setTooltip(inTooltip);
 }

--- a/Lib/Components/QuantizeForceSlider.h
+++ b/Lib/Components/QuantizeForceSlider.h
@@ -19,6 +19,8 @@ public:
 
     void paint(Graphics& g) override;
 
+    void setTooltip(const String& inTooltip);
+
 private:
     juce::Slider mSlider;
     std::unique_ptr<juce::SliderParameterAttachment> mAttachment;

--- a/Lib/Model/BasicPitch.cpp
+++ b/Lib/Model/BasicPitch.cpp
@@ -58,9 +58,9 @@ void BasicPitch::transcribeToMIDI(float* inAudio, int inNumSamples)
 
     const float* stacked_cqt = mFeaturesCalculator.computeFeatures(inAudio, inNumSamples, mNumFrames);
 
-    mOnsetsPG.resize(mNumFrames, std::vector<float>(NUM_FREQ_OUT, 0.0f));
-    mNotesPG.resize(mNumFrames, std::vector<float>(NUM_FREQ_OUT, 0.0f));
-    mContoursPG.resize(mNumFrames, std::vector<float>(NUM_FREQ_IN, 0.0f));
+    mOnsetsPG.resize(mNumFrames, std::vector<float>(static_cast<size_t>(NUM_FREQ_OUT), 0.0f));
+    mNotesPG.resize(mNumFrames, std::vector<float>(static_cast<size_t>(NUM_FREQ_OUT), 0.0f));
+    mContoursPG.resize(mNumFrames, std::vector<float>(static_cast<size_t>(NUM_FREQ_IN), 0.0f));
 
     mOnsetsPG.shrink_to_fit();
     mNotesPG.shrink_to_fit();

--- a/NeuralNote/Source/Components/NeuralNoteLNF.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteLNF.cpp
@@ -61,3 +61,17 @@ void NeuralNoteLNF::drawRotarySlider(Graphics& g,
 
     g.drawEllipse(bounds.getCentreX() - 16, bounds.getCentreY() - 16, 32, 32, 0.5f);
 }
+
+void NeuralNoteLNF::drawTooltip(Graphics& g, const String& text, int width, int height)
+{
+    g.setColour(WHITE_SOLID.darker(0.0f));
+    g.fillRoundedRectangle(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 5.0f);
+
+    g.setColour(BLACK);
+    g.setFont(LABEL_FONT);
+
+    auto text_std = text.toStdString();
+    int num_line_breaks = static_cast<int>(std::count(text_std.begin(), text_std.end(), '\n'));
+
+    g.drawFittedText(text, 0, 0, width, height, Justification::centred, num_line_breaks + 1);
+}

--- a/NeuralNote/Source/Components/NeuralNoteLNF.h
+++ b/NeuralNote/Source/Components/NeuralNoteLNF.h
@@ -30,6 +30,8 @@ public:
                           float rotaryStartAngle,
                           float rotaryEndAngle,
                           Slider&) override;
+
+    void drawTooltip(Graphics&, const String&, int, int) override;
 };
 
 #endif // NeuralNoteLNF_h

--- a/NeuralNote/Source/Components/NeuralNoteMainView.cpp
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.cpp
@@ -18,7 +18,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     mRecordButton->setClickingTogglesState(true);
     mRecordButton->setColour(DrawableButton::ColourIds::backgroundColourId, Colours::transparentBlack);
     mRecordButton->setColour(DrawableButton::ColourIds::backgroundOnColourId, Colours::transparentBlack);
-    mRecordButton->setTooltip("Record -- 'r'");
+    mRecordButton->setTooltip(NeuralNoteTooltips::record);
 
     auto record_off_drawable =
         Drawable::createFromImageData(BinaryData::recordingoff_svg, BinaryData::recordingoff_svgSize);
@@ -50,7 +50,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     mClearButton->setClickingTogglesState(false);
     mClearButton->setColour(DrawableButton::ColourIds::backgroundColourId, Colours::transparentBlack);
     mClearButton->setColour(DrawableButton::ColourIds::backgroundOnColourId, Colours::transparentBlack);
-    mClearButton->setTooltip("Clear audio and midi. -- Shift + Backspace");
+    mClearButton->setTooltip(NeuralNoteTooltips::clear);
 
     auto bin_drawable = Drawable::createFromImageData(BinaryData::deleteicon_svg, BinaryData::deleteicon_svgSize);
     mClearButton->setImages(bin_drawable.get());
@@ -73,7 +73,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
         mPlayPauseButton->setToggleState(false, sendNotification);
         mVisualizationPanel.getAudioMidiViewport().setViewPositionProportionately(0, 0);
     };
-    mBackButton->setTooltip("Go to start -- Shift + Space");
+    mBackButton->setTooltip(NeuralNoteTooltips::back);
     addAndMakeVisible(*mBackButton);
 
     mPlayPauseButton = std::make_unique<DrawableButton>("PlayPauseButton", DrawableButton::ButtonStyle::ImageRaw);
@@ -92,7 +92,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
             mPlayPauseButton->setToggleState(false, sendNotification);
         }
     };
-    mPlayPauseButton->setTooltip("Play/Pause -- Space");
+    mPlayPauseButton->setTooltip(NeuralNoteTooltips::play_pause);
 
     addAndMakeVisible(*mPlayPauseButton);
 
@@ -112,7 +112,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
                              nullptr,
                              nullptr,
                              nullptr);
-    mCenterButton->setTooltip("Center playhead -- 'c'");
+    mCenterButton->setTooltip(NeuralNoteTooltips::center);
 
     mCenterButton->getToggleStateValue().referTo(
         mProcessor.getValueTree().getPropertyAsValue(NnId::PlayheadCenteredId, nullptr));
@@ -191,7 +191,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     mMuteButton->setImages(
         mute_off_drawable.get(), nullptr, nullptr, nullptr, mute_on_drawable.get(), nullptr, nullptr);
     mMuteButton->setClickingTogglesState(true);
-    mMuteButton->setTooltip("Mute/Unmute input. -- 'm'");
+    mMuteButton->setTooltip(NeuralNoteTooltips::mute);
 
     mMuteButtonAttachment = std::make_unique<AudioProcessorValueTreeState::ButtonAttachment>(
         mProcessor.getAPVTS(), ParameterHelpers::getIdStr(ParameterHelpers::MuteId), *mMuteButton);
@@ -206,6 +206,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
                            .rescaled(1000, 640, Graphics::ResamplingQuality::highResamplingQuality);
 
     mTooltipWindow = std::make_unique<TooltipWindow>(this, 1000);
+    mTooltipWindow->setOpaque(false);
 
     setWantsKeyboardFocus(true);
     mPlayPauseButton->setWantsKeyboardFocus(false);
@@ -213,6 +214,7 @@ NeuralNoteMainView::NeuralNoteMainView(NeuralNoteAudioProcessor& processor)
     mRecordButton->setWantsKeyboardFocus(false);
     mCenterButton->setWantsKeyboardFocus(false);
     mSettingsButton->setWantsKeyboardFocus(false);
+    mSettingsButton->setTooltip(NeuralNoteTooltips::settings);
 
     updateEnablements();
 

--- a/NeuralNote/Source/Components/NeuralNoteMainView.h
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.h
@@ -35,6 +35,8 @@ public:
 
     void repaintPianoRoll();
 
+    bool keyPressed(const KeyPress& key) override;
+
 private:
     void updateEnablements();
 

--- a/NeuralNote/Source/Components/NeuralNoteMainView.h
+++ b/NeuralNote/Source/Components/NeuralNoteMainView.h
@@ -44,6 +44,8 @@ private:
 
     void _updateSettingsMenuTicks();
 
+    void _updateTooltipVisibility();
+
     NeuralNoteAudioProcessor& mProcessor;
     NeuralNoteLNF mLNF;
 

--- a/NeuralNote/Source/Components/Views/NoteOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/NoteOptionsView.cpp
@@ -14,6 +14,7 @@ NoteOptionsView::NoteOptionsView(NeuralNoteAudioProcessor& processor)
 
     mEnableButton->setColour(TextButton::buttonColourId, Colours::white.withAlpha(0.2f));
     mEnableButton->setColour(TextButton::buttonOnColourId, BLACK);
+    mEnableButton->setTooltip(NeuralNoteTooltips::sq_enable);
 
     mEnableAttachment = std::make_unique<AudioProcessorValueTreeState::ButtonAttachment>(
         mProcessor.getAPVTS(), ParameterHelpers::getIdStr(ParameterHelpers::EnableNoteQuantizationId), *mEnableButton);
@@ -21,20 +22,23 @@ NoteOptionsView::NoteOptionsView(NeuralNoteAudioProcessor& processor)
 
     mMinMaxNoteSlider = std::make_unique<MinMaxNoteSlider>(*mProcessor.getParams()[ParameterHelpers::MinMidiNoteId],
                                                            *mProcessor.getParams()[ParameterHelpers::MaxMidiNoteId]);
+    mMinMaxNoteSlider->setTooltip(NeuralNoteTooltips::sq_note_range);
     addAndMakeVisible(mMinMaxNoteSlider.get());
 
-    mKeyDropdown = std::make_unique<ComboBox>("KeyRootNoteDropDown");
-    mKeyDropdown->setEditableText(false);
-    mKeyDropdown->setJustificationType(Justification::centredLeft);
-    mKeyDropdown->addItemList(NoteUtils::RootNotesSharpStr, 1);
+    mRootNoteDropdown = std::make_unique<ComboBox>("KeyRootNoteDropDown");
+    mRootNoteDropdown->setEditableText(false);
+    mRootNoteDropdown->setJustificationType(Justification::centredLeft);
+    mRootNoteDropdown->addItemList(NoteUtils::RootNotesSharpStr, 1);
+    mRootNoteDropdown->setTooltip(NeuralNoteTooltips::sq_root_note);
     mKeyAttachment = std::make_unique<ComboBoxParameterAttachment>(
-        *mProcessor.getParams()[ParameterHelpers::KeyRootNoteId], *mKeyDropdown);
-    addAndMakeVisible(mKeyDropdown.get());
+        *mProcessor.getParams()[ParameterHelpers::KeyRootNoteId], *mRootNoteDropdown);
+    addAndMakeVisible(mRootNoteDropdown.get());
 
     mKeyType = std::make_unique<ComboBox>("ScaleTypeDropDown");
     mKeyType->setEditableText(false);
     mKeyType->setJustificationType(Justification::centredLeft);
     mKeyType->addItemList(NoteUtils::ScaleTypesStr, 1);
+    mKeyType->setTooltip(NeuralNoteTooltips::sq_scale_type);
     mKeyTypeAttachment =
         std::make_unique<ComboBoxParameterAttachment>(*mProcessor.getParams()[ParameterHelpers::KeyTypeId], *mKeyType);
     addAndMakeVisible(mKeyType.get());
@@ -43,6 +47,7 @@ NoteOptionsView::NoteOptionsView(NeuralNoteAudioProcessor& processor)
     mSnapMode->setEditableText(false);
     mSnapMode->setJustificationType(Justification::centredLeft);
     mSnapMode->addItemList(NoteUtils::SnapModesStr, 1);
+    mSnapMode->setTooltip(NeuralNoteTooltips::sq_snap_mode);
     mSnapModeAttachment = std::make_unique<ComboBoxParameterAttachment>(
         *mProcessor.getParams()[ParameterHelpers::KeySnapModeId], *mSnapMode);
     addAndMakeVisible(mSnapMode.get());
@@ -64,7 +69,7 @@ void NoteOptionsView::resized()
 {
     mEnableButton->setBounds(0, 0, 18, 18);
     mMinMaxNoteSlider->setBounds(64, 17 + LEFT_SECTIONS_TOP_PAD, 189, 17);
-    mKeyDropdown->setBounds(64, LEFT_SECTIONS_TOP_PAD + 46, 55, 17);
+    mRootNoteDropdown->setBounds(64, LEFT_SECTIONS_TOP_PAD + 46, 55, 17);
     mKeyType->setBounds(124, LEFT_SECTIONS_TOP_PAD + 46, 129, 17);
     mSnapMode->setBounds(100, LEFT_SECTIONS_TOP_PAD + 75, 154, 17);
 }
@@ -89,7 +94,7 @@ void NoteOptionsView::paint(Graphics& g)
     g.setFont(LABEL_FONT);
     g.drawText("RANGE", Rectangle<int>(19, mMinMaxNoteSlider->getY(), 80, 17), Justification::centredLeft);
 
-    g.drawText("KEY", Rectangle<int>(19, mKeyDropdown->getY(), 80, 17), Justification::centredLeft);
+    g.drawText("KEY", Rectangle<int>(19, mRootNoteDropdown->getY(), 80, 17), Justification::centredLeft);
 
     g.drawText("SNAP MODE", Rectangle<int>(19, mSnapMode->getY(), 80, 17), Justification::centredLeft);
 }
@@ -111,7 +116,7 @@ void NoteOptionsView::_enableView(bool inEnable)
 {
     mIsViewEnabled = inEnable;
     mMinMaxNoteSlider->setEnabled(inEnable);
-    mKeyDropdown->setEnabled(inEnable);
+    mRootNoteDropdown->setEnabled(inEnable);
     mKeyType->setEnabled(inEnable);
     mSnapMode->setEnabled(inEnable);
     repaint();

--- a/NeuralNote/Source/Components/Views/NoteOptionsView.h
+++ b/NeuralNote/Source/Components/Views/NoteOptionsView.h
@@ -12,6 +12,7 @@
 #include "UIDefines.h"
 #include "NoteUtils.h"
 #include "MinMaxNoteSlider.h"
+#include "NeuralNoteTooltips.h"
 
 class NeuralNoteMainView;
 
@@ -43,7 +44,7 @@ private:
 
     std::unique_ptr<MinMaxNoteSlider> mMinMaxNoteSlider;
 
-    std::unique_ptr<ComboBox> mKeyDropdown;
+    std::unique_ptr<ComboBox> mRootNoteDropdown;
     std::unique_ptr<ComboBoxParameterAttachment> mKeyAttachment;
 
     std::unique_ptr<ComboBox> mKeyType;

--- a/NeuralNote/Source/Components/Views/TimeQuantizeOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/TimeQuantizeOptionsView.cpp
@@ -11,6 +11,7 @@ TimeQuantizeOptionsView::TimeQuantizeOptionsView(NeuralNoteAudioProcessor& proce
     mEnableButton = std::make_unique<TextButton>("EnableTimeQuantizeOptionsButton");
     mEnableButton->setButtonText("");
     mEnableButton->setClickingTogglesState(true);
+    mEnableButton->setTooltip(NeuralNoteTooltips::tq_enable);
 
     mEnableButton->setColour(TextButton::buttonColourId, Colours::white.withAlpha(0.2f));
     mEnableButton->setColour(TextButton::buttonOnColourId, BLACK);
@@ -23,12 +24,14 @@ TimeQuantizeOptionsView::TimeQuantizeOptionsView(NeuralNoteAudioProcessor& proce
     mTimeDivisionDropdown->setEditableText(false);
     mTimeDivisionDropdown->setJustificationType(Justification::centredRight);
     mTimeDivisionDropdown->addItemList(TimeQuantizeUtils::TimeDivisionsStr, 1);
+    mTimeDivisionDropdown->setTooltip(NeuralNoteTooltips::tq_time_division);
     mTimeDivisionAttachment = std::make_unique<ComboBoxParameterAttachment>(
         *mProcessor.getParams()[ParameterHelpers::TimeDivisionId], *mTimeDivisionDropdown);
     addAndMakeVisible(*mTimeDivisionDropdown);
 
     mQuantizationForceSlider =
         std::make_unique<QuantizeForceSlider>(*mProcessor.getParams()[ParameterHelpers::QuantizationForceId]);
+    mQuantizationForceSlider->setTooltip(NeuralNoteTooltips::tq_quantization_force);
 
     addAndMakeVisible(*mQuantizationForceSlider);
 
@@ -129,6 +132,7 @@ void TimeQuantizeOptionsView::_setupTempoEditor()
     mTempoEditor = std::make_unique<NumericTextEditor<double>>(
         &mProcessor, NnId::TempoId, 6, 120.0, Justification::centredLeft, tempo_str_validator, tempo_str_corrector);
 
+    mTempoEditor->setTooltip(NeuralNoteTooltips::tq_tempo);
     addAndMakeVisible(mTempoEditor.get());
 }
 
@@ -155,6 +159,7 @@ void TimeQuantizeOptionsView::_setupTSEditors()
                                                                        Justification::centredRight,
                                                                        numerator_validator,
                                                                        numerator_corrector);
+    mTimeSignatureNumEditor->setTooltip(NeuralNoteTooltips::tq_numerator);
 
     addAndMakeVisible(mTimeSignatureNumEditor.get());
 
@@ -190,6 +195,7 @@ void TimeQuantizeOptionsView::_setupTSEditors()
                                                                          Justification::centredLeft,
                                                                          denominator_validator,
                                                                          denominator_corrector);
+    mTimeSignatureDenomEditor->setTooltip(NeuralNoteTooltips::tq_denominator);
 
     addAndMakeVisible(mTimeSignatureDenomEditor.get());
 }

--- a/NeuralNote/Source/Components/Views/TimeQuantizeOptionsView.h
+++ b/NeuralNote/Source/Components/Views/TimeQuantizeOptionsView.h
@@ -12,6 +12,7 @@
 #include "TimeQuantizeUtils.h"
 #include "QuantizeForceSlider.h"
 #include "NumericTextEditor.h"
+#include "NeuralNoteTooltips.h"
 
 class NeuralNoteMainView;
 

--- a/NeuralNote/Source/Components/Views/TranscriptionOptionsView.cpp
+++ b/NeuralNote/Source/Components/Views/TranscriptionOptionsView.cpp
@@ -10,20 +10,24 @@ TranscriptionOptionsView::TranscriptionOptionsView(NeuralNoteAudioProcessor& pro
 {
     mNoteSensibility =
         std::make_unique<Knob>(*mProcessor.getParams()[ParameterHelpers::NoteSensibilityId], "NOTE SENSIBILITY", false);
+    mNoteSensibility->setTooltip(NeuralNoteTooltips::to_note_sensibility);
     addAndMakeVisible(*mNoteSensibility);
 
     mSplitSensibility = std::make_unique<Knob>(
         *mProcessor.getParams()[ParameterHelpers::SplitSensibilityId], "SPLIT SENSIBILITY", false);
+    mSplitSensibility->setTooltip(NeuralNoteTooltips::to_split_sensibility);
     addAndMakeVisible(*mSplitSensibility);
 
     mMinNoteDuration = std::make_unique<Knob>(
         *mProcessor.getParams()[ParameterHelpers::MinimumNoteDurationId], "MIN NOTE DURATION", false, " ms");
+    mMinNoteDuration->setTooltip(NeuralNoteTooltips::to_min_note_duration);
     addAndMakeVisible(*mMinNoteDuration);
 
     mPitchBendDropDown = std::make_unique<juce::ComboBox>("PITCH BEND");
     mPitchBendDropDown->setEditableText(false);
     mPitchBendDropDown->setJustificationType(juce::Justification::centredLeft);
     mPitchBendDropDown->addItemList({"No Pitch Bend", "Single Pitch Bend"}, 1);
+    mPitchBendDropDown->setTooltip(NeuralNoteTooltips::to_pitch_bend);
     mPitchBendDropDownParameterAttachment = std::make_unique<ComboBoxParameterAttachment>(
         *mProcessor.getParams()[ParameterHelpers::PitchBendModeId], *mPitchBendDropDown);
 

--- a/NeuralNote/Source/Components/Views/TranscriptionOptionsView.h
+++ b/NeuralNote/Source/Components/Views/TranscriptionOptionsView.h
@@ -10,6 +10,7 @@
 #include "PluginProcessor.h"
 #include "Knob.h"
 #include "UIDefines.h"
+#include "NeuralNoteTooltips.h"
 
 class NeuralNoteMainView;
 

--- a/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
+++ b/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
@@ -4,6 +4,8 @@
 
 #include "VisualizationPanel.h"
 
+#include <NeuralNoteTooltips.h>
+
 VisualizationPanel::VisualizationPanel(NeuralNoteAudioProcessor* processor)
     : mProcessor(processor)
     , mCombinedAudioMidiRegion(processor, mKeyboard)
@@ -33,6 +35,7 @@ VisualizationPanel::VisualizationPanel(NeuralNoteAudioProcessor* processor)
 
     mFileTempo = std::make_unique<NumericTextEditor<double>>(
         mProcessor, NnId::ExportTempoId, 6, 120.0, Justification::centred, tempo_str_validator, tempo_str_corrector);
+    mFileTempo->setTooltip(NeuralNoteTooltips::export_tempo);
     addChildComponent(*mFileTempo);
 
     mAudioGainSlider.setSliderStyle(Slider::SliderStyle::LinearHorizontal);

--- a/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
+++ b/NeuralNote/Source/Components/Views/VisualizationPanel.cpp
@@ -45,6 +45,7 @@ VisualizationPanel::VisualizationPanel(NeuralNoteAudioProcessor* processor)
     mAudioGainSlider.setColour(Slider::ColourIds::textBoxOutlineColourId, Colours::transparentWhite);
     // To also receive mouseExit callback from this slider
     mAudioGainSlider.addMouseListener(this, true);
+    mAudioGainSlider.setTooltip(NeuralNoteTooltips::source_audio_level);
     mAudioGainSliderAttachment = std::make_unique<SliderParameterAttachment>(
         *mProcessor->getParams()[ParameterHelpers::AudioPlayerGainId], mAudioGainSlider);
 
@@ -57,6 +58,7 @@ VisualizationPanel::VisualizationPanel(NeuralNoteAudioProcessor* processor)
     mMidiGainSlider.setColour(Slider::ColourIds::textBoxOutlineColourId, Colours::transparentWhite);
     // To also receive mouseExit callback from this slider
     mMidiGainSlider.addMouseListener(this, true);
+    mMidiGainSlider.setTooltip(NeuralNoteTooltips::internal_synth_level);
 
     mMidiGainSliderAttachment = std::make_unique<SliderParameterAttachment>(
         *mProcessor->getParams()[ParameterHelpers::MidiPlayerGainId], mMidiGainSlider);

--- a/NeuralNote/Source/NeuralNoteTooltips.h
+++ b/NeuralNote/Source/NeuralNoteTooltips.h
@@ -1,0 +1,70 @@
+//
+// Created by Damien Ronssin on 01/12/2024.
+//
+
+#ifndef NEURALNOTETOOLTIPS_H
+#define NEURALNOTETOOLTIPS_H
+
+#include <JuceHeader.h>
+
+namespace NeuralNoteTooltips
+{
+// Transcription options
+const String to_note_sensibility = "Set note sensibility\n"
+                                   "Higher values will detect more notes";
+
+const String to_split_sensibility = "Set split sensibility\n"
+                                    "Higher values result in more splits\nLower values results in longer held notes";
+
+const String to_min_note_duration = "Set minimum note duration\n"
+                                    "Notes shorter than this are removed";
+
+const String to_pitch_bend = "Set pitch bend mode\n"
+                             "No Pitch Bend: Transcription will not include any pitch bend\n"
+                             "Single Pitch Bend: Transcription will include pitch bend for non-overlapping notes";
+
+// Scale quantization
+const String sq_enable = "Enable / Disable scale quantization";
+
+const String sq_note_range = "Set note range";
+
+const String sq_root_note = "Set scale root note";
+
+const String sq_scale_type = "Set scale type";
+
+const String sq_snap_mode = "Set snap mode\nAdjust: snap to closest note in scale\nRemove: remove if not in scale";
+
+// Time quantization
+const String tq_enable = "Enable / Disable time quantization";
+
+const String tq_time_division = "Set time division to quantize to";
+
+const String tq_quantization_force = "Set quantization force";
+
+const String tq_tempo = "Set tempo";
+
+const String tq_numerator = "Set time signature numerator";
+
+const String tq_denominator = "Set time signature denominator";
+
+// Controls
+
+const String record = "Record | r";
+
+const String clear = "Clear audio and midi | Shift + Backspace";
+
+const String play_pause = "Play / Pause | Space";
+
+const String back = "Go to start | Shift + Space";
+
+const String center = "Center playhead | c";
+
+const String settings = "Settings";
+
+const String mute = "Mute / Unmute input | m";
+
+const String export_tempo = "Set export tempo for midi file";
+
+} // namespace NeuralNoteTooltips
+
+#endif //NEURALNOTETOOLTIPS_H

--- a/NeuralNote/Source/NeuralNoteTooltips.h
+++ b/NeuralNote/Source/NeuralNoteTooltips.h
@@ -65,6 +65,10 @@ const String mute = "Mute / Unmute input | m";
 
 const String export_tempo = "Set export tempo for midi file";
 
+const String source_audio_level = "Set source audio level";
+
+const String internal_synth_level = "Set internal synth level";
+
 } // namespace NeuralNoteTooltips
 
 #endif //NEURALNOTETOOLTIPS_H

--- a/NeuralNote/Source/NnId.h
+++ b/NeuralNote/Source/NnId.h
@@ -29,6 +29,12 @@ inline static Identifier PlayheadCenteredId = "PLAYHEAD_CENTERED";
 
 inline static Identifier MidiOut = "MIDI_OUT";
 
+inline static Identifier ExportTempoId = "EXPORT_TEMPO";
+
+inline static Identifier ZoomLevelId = "ZOOM_LEVEL";
+
+inline static Identifier TooltipVisibleId = "TOOLTIP_VISIBLE";
+
 // --------------- Time quantization ----------------
 inline static Identifier TempoId = "TEMPO";
 
@@ -41,10 +47,6 @@ inline static Identifier TimeQuantizeRefPosQnId = "TIME_QUANTIZE_REF_POS_QN";
 inline static Identifier TimeQuantizeRefLastBarQnId = "TIME_QUANTIZE_REF_LAST_BAR_QN";
 
 inline static Identifier TimeQuantizeRefPosSec = "TIME_QUANTIZE_REF_POS_SECONDS";
-
-inline static Identifier ExportTempoId = "EXPORT_TEMPO";
-
-inline static Identifier ZoomLevelId = "ZOOM_LEVEL";
 
 // To be set in this specific order
 const std::vector<std::pair<Identifier, var>> OrderedStatePropertiesWithDefault = {
@@ -59,7 +61,9 @@ const std::vector<std::pair<Identifier, var>> OrderedStatePropertiesWithDefault 
     {PlayheadPositionSecId, 0.0},
     {PlayheadCenteredId, true},
     {ZoomLevelId, 1.0},
-    {MidiOut, false}};
+    {MidiOut, false},
+    {TooltipVisibleId, true}};
+
 } // namespace NnId
 
 #endif //NNID_H


### PR DESCRIPTION
# Shortcuts
- `space`: play / pause
- `shift + space`: go back
- `shift + backspace`: clear
- `m`: mute
- `r`: record
- `c`: center playhead: 

# Tooltips
- Added tooltips to every button, knob or slider.
- Added option to enable/disable tooltips.